### PR TITLE
Fcopy should call pwrite64 directly.

### DIFF
--- a/hv-rhel5.x/hv/tools/hv_fcopy_daemon.c
+++ b/hv-rhel5.x/hv/tools/hv_fcopy_daemon.c
@@ -105,7 +105,7 @@ static int hv_copy_data(struct hv_do_fcopy *cpmsg)
 {
 	ssize_t bytes_written;
 
-	bytes_written = pwrite(target_fd, cpmsg->data, cpmsg->size,
+	bytes_written = pwrite64(target_fd, cpmsg->data, cpmsg->size,
 				cpmsg->offset);
 
 	if (bytes_written != cpmsg->size)


### PR DESCRIPTION
This bug has only been observed on RHEL 5.X. When the file offset exceeds 2GB, our daemon calls into pwrite with the right value; but the pwrite wrapper logic corrupts this offset prior to passing it to the pwrite64 call.