### PR TITLE
RH7: scsi: storvsc: Do not mask out the SRB_STATUS_AUTOSENSE_VALID bi…

### DIFF
--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -384,7 +384,8 @@ enum storvsc_request_type {
 #define SRB_STATUS_ERROR	0x04
 
 #define SRB_STATUS(status) \
-	(status & ~(SRB_STATUS_AUTOSENSE_VALID | SRB_STATUS_QUEUE_FROZEN))
+	(status & ~(SRB_STATUS_QUEUE_FROZEN))
+
 /*
  * This is the end of Protocol specific defines.
  */


### PR DESCRIPTION
…t in the SRB_STATUS macro. This only effects RHEL 7.x