### PR TITLE
cppcheck issues

### DIFF
--- a/hv-rhel6.x/hv/provider.c
+++ b/hv-rhel6.x/hv/provider.c
@@ -823,11 +823,11 @@ static int hvnd_ib_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
 	enum ib_qp_state cur_state, new_state;
 	int ret = 0;
 
-
-	cur_state = attr_mask & IB_QP_CUR_STATE ? attr->cur_qp_state : qp->qp_state;
-	new_state = attr_mask & IB_QP_STATE ? attr->qp_state : cur_state;
-
 	if (attr != NULL) {
+
+        	cur_state = attr_mask & IB_QP_CUR_STATE ? attr->cur_qp_state : qp->qp_state;
+        	new_state = attr_mask & IB_QP_STATE ? attr->qp_state : cur_state;
+
 		hvnd_debug("qp->qp_state is %d new state is %d\n", qp->qp_state, new_state);
 		hvnd_debug("current qp state is %d\n", cur_state);
 		if (attr_mask & IB_QP_STATE) {

--- a/hv-rhel7.x/hv/provider.c
+++ b/hv-rhel7.x/hv/provider.c
@@ -842,11 +842,11 @@ static int hvnd_ib_modify_qp(struct ib_qp *ibqp, struct ib_qp_attr *attr,
 	enum ib_qp_state cur_state, new_state;
 	int ret = 0;
 
-
-	cur_state = attr_mask & IB_QP_CUR_STATE ? attr->cur_qp_state : qp->qp_state;
-	new_state = attr_mask & IB_QP_STATE ? attr->qp_state : cur_state;
-
 	if (attr != NULL) {
+
+	        cur_state = attr_mask & IB_QP_CUR_STATE ? attr->cur_qp_state : qp->qp_state;
+	   	new_state = attr_mask & IB_QP_STATE ? attr->qp_state : cur_state;
+
 		hvnd_debug("qp->qp_state is %d new state is %d\n", qp->qp_state, new_state);
 		hvnd_debug("current qp state is %d\n", cur_state);
 		if (attr_mask & IB_QP_STATE) {


### PR DESCRIPTION
[hv-rhel6.x/hv/provider.c:827] -> [hv-rhel6.x/hv/provider.c:830]: (warning) Either the condition 'attr!=0' is redundant or there is possible null pointer dereference: attr.
[hv-rhel6.x/hv/provider.c:828] -> [hv-rhel6.x/hv/provider.c:830]: (warning) Either the condition 'attr!=0' is redundant or there is possible null pointer dereference: attr.

[hv-rhel7.x/hv/provider.c:846] -> [hv-rhel7.x/hv/provider.c:849]: (warning) Either the condition 'attr!=0' is redundant or there is possible null pointer dereference: attr.
[hv-rhel7.x/hv/provider.c:847] -> [hv-rhel7.x/hv/provider.c:849]: (warning) Either the condition 'attr!=0' is redundant or there is possible null pointer dereference: attr.