### PR TITLE
cppcheck issues

### DIFF
--- a/hv-rhel6.x/hv/provider.c
+++ b/hv-rhel6.x/hv/provider.c
@@ -1571,13 +1571,14 @@ static int hvnd_accept_cr(struct iw_cm_id *cm_id,
 
 	connector = (struct hvnd_ep_obj *)cm_id->provider_data;
 	qp->connector = connector;
-	connector->cq = qp->recv_cq;
 
 	if (connector == NULL) {
 		hvnd_error("NULL connector!\n");
 		return -EINVAL;
 	}
 	hvnd_debug("connector's cm_id is %p caller cm_id=%p\n", connector->cm_id, cm_id);
+
+	connector->cq = qp->recv_cq;
 
 
 	/*

--- a/hv-rhel7.x/hv/provider.c
+++ b/hv-rhel7.x/hv/provider.c
@@ -1600,13 +1600,14 @@ static int hvnd_accept_cr(struct iw_cm_id *cm_id,
 
 	connector = (struct hvnd_ep_obj *)cm_id->provider_data;
 	qp->connector = connector;
-	connector->cq = qp->recv_cq;
 
 	if (connector == NULL) {
 		hvnd_error("NULL connector!\n");
 		return -EINVAL;
 	}
 	hvnd_debug("connector's cm_id is %p caller cm_id=%p\n", connector->cm_id, cm_id);
+
+	connector->cq = qp->recv_cq;
 
 
 	/*


### PR DESCRIPTION
[hv-rhel6.x/hv/provider.c:1574] -> [hv-rhel6.x/hv/provider.c:1576]: (warning) Either the condition 'connector==0' is redundant or there is possible null pointer dereference: connector.
[hv-rhel7.x/hv/provider.c:1603] -> [hv-rhel7.x/hv/provider.c:1605]: (warning) Either the condition 'connector==0' is redundant or there is possible null pointer dereference: connector.