### PR TITLE
cppcheck issues

### DIFF
--- a/hv-rhel6.x/hv/provider.c
+++ b/hv-rhel6.x/hv/provider.c
@@ -1586,10 +1586,13 @@ static int hvnd_accept_cr(struct iw_cm_id *cm_id,
 	 */
 	cm_id->add_ref(cm_id);
 	connector->cm_id = cm_id;
-	if (conn_param != NULL) {
-		connector->ord = conn_param->ord;
-		connector->ird = conn_param->ird;
+	if (conn_param == NULL) {
+		hvnd_error("NULL conn_param!\n");
+		return -EINVAL;
 	}
+
+        connector->ord = conn_param->ord;
+        connector->ird = conn_param->ird;
 
 	if (!ep_add_work_pending(connector))
 		goto error;

--- a/hv-rhel7.x/hv/provider.c
+++ b/hv-rhel7.x/hv/provider.c
@@ -1615,10 +1615,13 @@ static int hvnd_accept_cr(struct iw_cm_id *cm_id,
 	 */
 	cm_id->add_ref(cm_id);
 	connector->cm_id = cm_id;
-	if (conn_param != NULL) {
-		connector->ord = conn_param->ord;
-		connector->ird = conn_param->ird;
-	}
+        if (conn_param == NULL) {
+                hvnd_error("NULL conn_param!\n");
+                return -EINVAL;
+        }
+
+        connector->ord = conn_param->ord;
+        connector->ird = conn_param->ird;
 
 	if (!ep_add_work_pending(connector))
 		goto error;


### PR DESCRIPTION
[hv-rhel6.x/hv/provider.c:1600] -> [hv-rhel6.x/hv/provider.c:1589]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.
[hv-rhel6.x/hv/provider.c:1601] -> [hv-rhel6.x/hv/provider.c:1589]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.
[hv-rhel6.x/hv/provider.c:1602] -> [hv-rhel6.x/hv/provider.c:1589]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.
[hv-rhel7.x/hv/provider.c:1629] -> [hv-rhel7.x/hv/provider.c:1618]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.
[hv-rhel7.x/hv/provider.c:1630] -> [hv-rhel7.x/hv/provider.c:1618]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.
[hv-rhel7.x/hv/provider.c:1631] -> [hv-rhel7.x/hv/provider.c:1618]: (warning) Either the condition 'conn_param!=0' is redundant or there is possible null pointer dereference: conn_param.