### PR TITLE
cppcheck issues

### DIFF
--- a/hv-rhel5.x/hv/hid-core.c
+++ b/hv-rhel5.x/hv/hid-core.c
@@ -1247,7 +1247,7 @@ int hid_input_report(struct hid_device *hid, int type, u8 *data, int size, int i
 
 	/* dump the report */
 	snprintf(buf, HID_DEBUG_BUFSIZE - 1,
-			"\nreport (size %u) (%snumbered) = ", size, report_enum->numbered ? "" : "un");
+			"\nreport (size %d) (%snumbered) = ", size, report_enum->numbered ? "" : "un");
 	hid_debug_event(hid, buf);
 
 	for (i = 0; i < size; i++) {

--- a/hv-rhel7.x/hv/hid-core.c
+++ b/hv-rhel7.x/hv/hid-core.c
@@ -1247,7 +1247,7 @@ int hid_input_report(struct hid_device *hid, int type, u8 *data, int size, int i
 
 	/* dump the report */
 	snprintf(buf, HID_DEBUG_BUFSIZE - 1,
-			"\nreport (size %u) (%snumbered) = ", size, report_enum->numbered ? "" : "un");
+			"\nreport (size %d) (%snumbered) = ", size, report_enum->numbered ? "" : "un");
 	hid_debug_event(hid, buf);
 
 	for (i = 0; i < size; i++) {


### PR DESCRIPTION
[hv-rhel5.x/hv/hid-core.c:1249]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.
[hv-rhel7.x/hv/hid-core.c:1249]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.