### PR TITLE
RH6: fixed compile issue with skb_tx_timestamp() which was introduced…

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -652,8 +652,11 @@ do_send:
 	packet->total_data_buflen = rndis_msg->msg_len;
 	packet->page_buf_cnt = init_page_array(rndis_msg, rndis_msg_size,
 					       skb, packet, &pb);
+
+#if defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,3))
 	/* timestamp packet in software */
 	skb_tx_timestamp(skb);
+#endif
 
 	ret = netvsc_send(net_device_ctx->device_ctx, packet,
 			  rndis_msg, &pb, skb);


### PR DESCRIPTION
… in the RHEL 6.4 kernel