### PR TITLE
Revert "RH5: storvsc: set the block max size to VSP reported value"

### DIFF
--- a/hv-rhel5.x/hv/storvsc_drv.c
+++ b/hv-rhel5.x/hv/storvsc_drv.c
@@ -1573,12 +1573,6 @@ static void storvsc_device_destroy(struct scsi_device *sdevice)
 
 static int storvsc_device_configure(struct scsi_device *sdevice)
 {
-	struct hv_host_device *host_dev = shost_priv(sdevice->host);
-	struct storvsc_device *stor_device = get_out_stor_device(host_dev->dev);
-	unsigned int max_transfer_sectors = stor_device->max_transfer_bytes >> 9;
-
-	blk_queue_max_hw_sectors(sdevice->request_queue, max_transfer_sectors);
-	sdevice->request_queue->limits.max_sectors = max_transfer_sectors;
 
 	blk_queue_bounce_limit(sdevice->request_queue, BLK_BOUNCE_ANY);
 


### PR DESCRIPTION
This reverts commit 8fa3a2c1ed4256d9779cb32557dc4a03fdb497b1.

This was causing a build break on RH5.X