### PR TITLE
Merge storvsc reverts from master to 1605 branch

### DIFF
--- a/hv-rhel6.x/hv/storvsc_drv.c
+++ b/hv-rhel6.x/hv/storvsc_drv.c
@@ -1681,12 +1681,6 @@ static void storvsc_device_destroy(struct scsi_device *sdevice)
 
 static int storvsc_device_configure(struct scsi_device *sdevice)
 {
-	struct hv_host_device *host_dev = shost_priv(sdevice->host);
-	struct storvsc_device *stor_device = get_out_stor_device(host_dev->dev);
-	unsigned int max_transfer_sectors = stor_device->max_transfer_bytes >> 9;
-
-	blk_queue_max_hw_sectors(sdevice->request_queue, max_transfer_sectors);
-	sdevice->request_queue->limits.max_sectors = max_transfer_sectors;
 
 	blk_queue_bounce_limit(sdevice->request_queue, BLK_BOUNCE_ANY);
 

--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -1687,12 +1687,6 @@ static void storvsc_device_destroy(struct scsi_device *sdevice)
 
 static int storvsc_device_configure(struct scsi_device *sdevice)
 {
-	struct hv_host_device *host_dev = shost_priv(sdevice->host);
-	struct storvsc_device *stor_device = get_out_stor_device(host_dev->dev);
-	unsigned int max_transfer_sectors = stor_device->max_transfer_bytes >> 9;
-
-	blk_queue_max_hw_sectors(sdevice->request_queue, max_transfer_sectors);
-	sdevice->request_queue->limits.max_sectors = max_transfer_sectors;
 
 	blk_queue_bounce_limit(sdevice->request_queue, BLK_BOUNCE_ANY);
 


### PR DESCRIPTION
The revert to the 5.x tree was done on June 15.  This is for the 6.x and 7.x trees.  Tested on 7.2, 7.0, 6.8x64, 6.7x64, 6.0x32, 5.11x64, 5.8x64, 5.5x32, 5.3x32.