### PR TITLE
backport KY's patches which addressed the host side throttling

### DIFF
--- a/hv-rhel6.x/hv/channel.c
+++ b/hv-rhel6.x/hv/channel.c
@@ -723,10 +723,18 @@ int vmbus_sendpacket_ctl(struct vmbus_channel *channel, void *buffer,
          * NOTE: in this case, the hvsock channel is an exception, because
          * it looks the host side's hvsock implementation has a throttling
          * mechanism which can hurt the performance otherwise.
+	 *
+	 * KYS: Oct. 30, 2016:
+	 * It looks like Windows hosts have logic to deal with DOS attacks that
+	 * can be triggered if it receives interrupts when it is not expecting
+	 * the interrupt. The host expects interrupts only when the ring
+	 * transitions from empty to non-empty (or full to non full on the guest
+	 * to host ring).
+	 * So, base the signaling decision solely on the ring state until the
+	 * host logic is fixed.
          */
 
-        if (((ret == 0) && kick_q && signal) ||
-            (ret && !is_hvsock_channel(channel)))
+	if (((ret == 0) && signal))
 		vmbus_setevent(channel);
 
 	return ret;
@@ -833,9 +841,18 @@ int vmbus_sendpacket_pagebuffer_ctl(struct vmbus_channel *channel,
          * If we cannot write to the ring-buffer; signal the host
          * even if we may not have written anything. This is a rare
          * enough condition that it should not matter.
+	 *
+	 * KYS: Oct. 30, 2016:
+	 * It looks like Windows hosts have logic to deal with DOS attacks that
+	 * can be triggered if it receives interrupts when it is not expecting
+	 * the interrupt. The host expects interrupts only when the ring
+	 * transitions from empty to non-empty (or full to non full on the guest
+	 * to host ring).
+	 * So, base the signaling decision solely on the ring state until the
+	 * host logic is fixed.
          */
 
-        if (((ret == 0) && kick_q && signal) || (ret))
+	if (((ret == 0) && signal))
                 vmbus_setevent(channel);
 
 	return ret;

--- a/hv-rhel6.x/hv/channel.c
+++ b/hv-rhel6.x/hv/channel.c
@@ -39,7 +39,7 @@
  * vmbus_setevent- Trigger an event notification on the specified
  * channel.
  */
-static void vmbus_setevent(struct vmbus_channel *channel)
+void vmbus_setevent(struct vmbus_channel *channel)
 {
 	struct hv_monitor_page *monitorpage;
 
@@ -65,6 +65,7 @@ static void vmbus_setevent(struct vmbus_channel *channel)
 		vmbus_set_event(channel);
 	}
 }
+EXPORT_SYMBOL_GPL(vmbus_setevent);
 
 /*
  * vmbus_get_debug_info -Retrieve various channel debug info
@@ -682,8 +683,6 @@ int vmbus_sendpacket_ctl(struct vmbus_channel *channel, void *buffer,
 	u32 packetlen_aligned = ALIGN(packetlen, sizeof(u64));
 	struct kvec bufferlist[3];
 	u64 aligned_data = 0;
-	int ret;
-	bool signal = false;
 	bool lock = channel->acquire_ring_lock;
 	int num_vecs = ((bufferlen != 0) ? 3 : 1);
 
@@ -703,42 +702,8 @@ int vmbus_sendpacket_ctl(struct vmbus_channel *channel, void *buffer,
 	bufferlist[2].iov_base = &aligned_data;
 	bufferlist[2].iov_len = (packetlen_aligned - packetlen);
 
-	ret = hv_ringbuffer_write(&channel->outbound, bufferlist, num_vecs,
-				  &signal, lock, channel->signal_policy);
-
-	/*
-         * Signalling the host is conditional on many factors:
-         * 1. The ring state changed from being empty to non-empty.
-         *    This is tracked by the variable "signal".
-         * 2. The variable kick_q tracks if more data will be placed
-         *    on the ring. We will not signal if more data is
-         *    to be placed.
-         *
-         * Based on the channel signal state, we will decide
-         * which signaling policy will be applied.
-         *
-         * If we cannot write to the ring-buffer; signal the host
-         * even if we may not have written anything. This is a rare
-         * enough condition that it should not matter.
-         * NOTE: in this case, the hvsock channel is an exception, because
-         * it looks the host side's hvsock implementation has a throttling
-         * mechanism which can hurt the performance otherwise.
-	 *
-	 * KYS: Oct. 30, 2016:
-	 * It looks like Windows hosts have logic to deal with DOS attacks that
-	 * can be triggered if it receives interrupts when it is not expecting
-	 * the interrupt. The host expects interrupts only when the ring
-	 * transitions from empty to non-empty (or full to non full on the guest
-	 * to host ring).
-	 * So, base the signaling decision solely on the ring state until the
-	 * host logic is fixed.
-         */
-
-	if (((ret == 0) && signal))
-		vmbus_setevent(channel);
-
-	return ret;
-
+	return hv_ringbuffer_write(channel, bufferlist, num_vecs,
+					lock, kick_q);
 }
 EXPORT_SYMBOL(vmbus_sendpacket_ctl);
 
@@ -779,7 +744,6 @@ int vmbus_sendpacket_pagebuffer_ctl(struct vmbus_channel *channel,
 				     u32 flags,
 				     bool kick_q)
 {
-	int ret;
 	int i;
 	struct vmbus_channel_packet_page_buffer desc;
 	u32 descsize;
@@ -787,7 +751,6 @@ int vmbus_sendpacket_pagebuffer_ctl(struct vmbus_channel *channel,
 	u32 packetlen_aligned;
 	struct kvec bufferlist[3];
 	u64 aligned_data = 0;
-	bool signal = false;
 	bool lock = channel->acquire_ring_lock;
 	if (pagecount > MAX_PAGE_BUFFER_COUNT)
 		return -EINVAL;
@@ -824,38 +787,8 @@ int vmbus_sendpacket_pagebuffer_ctl(struct vmbus_channel *channel,
 	bufferlist[2].iov_base = &aligned_data;
 	bufferlist[2].iov_len = (packetlen_aligned - packetlen);
 
-	ret = hv_ringbuffer_write(&channel->outbound, bufferlist, 3,
-				  &signal, lock, channel->signal_policy);
-
-	/*
-         * Signalling the host is conditional on many factors:
-         * 1. The ring state changed from being empty to non-empty.
-         *    This is tracked by the variable "signal".
-         * 2. The variable kick_q tracks if more data will be placed
-         *    on the ring. We will not signal if more data is
-         *    to be placed.
-         *
-         * Based on the channel signal state, we will decide
-         * which signaling policy will be applied.
-         *
-         * If we cannot write to the ring-buffer; signal the host
-         * even if we may not have written anything. This is a rare
-         * enough condition that it should not matter.
-	 *
-	 * KYS: Oct. 30, 2016:
-	 * It looks like Windows hosts have logic to deal with DOS attacks that
-	 * can be triggered if it receives interrupts when it is not expecting
-	 * the interrupt. The host expects interrupts only when the ring
-	 * transitions from empty to non-empty (or full to non full on the guest
-	 * to host ring).
-	 * So, base the signaling decision solely on the ring state until the
-	 * host logic is fixed.
-         */
-
-	if (((ret == 0) && signal))
-                vmbus_setevent(channel);
-
-	return ret;
+	return hv_ringbuffer_write(channel, bufferlist, 3,
+					lock, kick_q);
 }
 EXPORT_SYMBOL_GPL(vmbus_sendpacket_pagebuffer_ctl);
 
@@ -871,9 +804,7 @@ int vmbus_sendpacket_hvsock(struct vmbus_channel *channel, void *buf, u32 len)
 	u32 packetlen_aligned;
 	u32 packetlen;
 	u64 aligned_data = 0;
-	bool signal = false;
 	bool lock = channel->acquire_ring_lock;
-	int ret;
 
 	packetlen = HVSOCK_HEADER_LEN + len;
 	packetlen_aligned = ALIGN(packetlen, sizeof(u64));
@@ -898,13 +829,8 @@ int vmbus_sendpacket_hvsock(struct vmbus_channel *channel, void *buf, u32 len)
 	bufferlist[3].iov_base = &aligned_data;
 	bufferlist[3].iov_len  = packetlen_aligned - packetlen;
 
-	ret = hv_ringbuffer_write(&channel->outbound, bufferlist, 4,
-				  &signal, lock, channel->signal_policy);
-
-	if (ret == 0 && signal)
-		vmbus_setevent(channel);
-
-	return ret;
+	return hv_ringbuffer_write(channel, bufferlist, 4,
+					lock, true);
 }
 EXPORT_SYMBOL_GPL(vmbus_sendpacket_hvsock);
 
@@ -936,12 +862,10 @@ int vmbus_sendpacket_mpb_desc(struct vmbus_channel *channel,
 			      u32 desc_size,
 			      void *buffer, u32 bufferlen, u64 requestid)
 {
-	int ret;
 	u32 packetlen;
 	u32 packetlen_aligned;
 	struct kvec bufferlist[3];
 	u64 aligned_data = 0;
-	bool signal = false;
 	bool lock = channel->acquire_ring_lock;
 
 	packetlen = desc_size + bufferlen;
@@ -962,13 +886,8 @@ int vmbus_sendpacket_mpb_desc(struct vmbus_channel *channel,
 	bufferlist[2].iov_base = &aligned_data;
 	bufferlist[2].iov_len = (packetlen_aligned - packetlen);
 
-	ret = hv_ringbuffer_write(&channel->outbound, bufferlist, 3,
-				  &signal, lock, channel->signal_policy);
-
-	if (ret == 0 && signal)
-		vmbus_setevent(channel);
-
-	return ret;
+	return hv_ringbuffer_write(channel, bufferlist, 3,
+					lock, true);
 }
 EXPORT_SYMBOL_GPL(vmbus_sendpacket_mpb_desc);
 
@@ -980,14 +899,12 @@ int vmbus_sendpacket_multipagebuffer(struct vmbus_channel *channel,
 				struct hv_multipage_buffer *multi_pagebuffer,
 				void *buffer, u32 bufferlen, u64 requestid)
 {
-	int ret;
 	struct vmbus_channel_packet_multipage_buffer desc;
 	u32 descsize;
 	u32 packetlen;
 	u32 packetlen_aligned;
 	struct kvec bufferlist[3];
 	u64 aligned_data = 0;
-	bool signal = false;
 	bool lock = channel->acquire_ring_lock;
 	u32 pfncount = NUM_PAGES_SPANNED(multi_pagebuffer->offset,
 					 multi_pagebuffer->len);
@@ -1027,13 +944,8 @@ int vmbus_sendpacket_multipagebuffer(struct vmbus_channel *channel,
 	bufferlist[2].iov_base = &aligned_data;
 	bufferlist[2].iov_len = (packetlen_aligned - packetlen);
 
-	ret = hv_ringbuffer_write(&channel->outbound, bufferlist, 3,
-				  &signal, lock, channel->signal_policy);
-
-	if (ret == 0 && signal)
-		vmbus_setevent(channel);
-
-	return ret;
+	return hv_ringbuffer_write(channel, bufferlist, 3,
+					lock, true);
 }
 EXPORT_SYMBOL_GPL(vmbus_sendpacket_multipagebuffer);
 

--- a/hv-rhel6.x/hv/channel.c
+++ b/hv-rhel6.x/hv/channel.c
@@ -967,16 +967,8 @@ __vmbus_recvpacket(struct vmbus_channel *channel, void *buffer,
 		   u32 bufferlen, u32 *buffer_actual_len, u64 *requestid,
 		   bool raw)
 {
-	int ret;
-	bool signal = false;
-
-	ret = hv_ringbuffer_read(&channel->inbound, buffer, bufferlen,
-		 		 buffer_actual_len, requestid, &signal, raw);
-
-	if (signal)
-		vmbus_setevent(channel);
-
-	return ret;
+	return hv_ringbuffer_read(channel, buffer, bufferlen,
+		buffer_actual_len, requestid, raw);
 }
 
 int vmbus_recvpacket(struct vmbus_channel *channel, void *buffer,

--- a/hv-rhel6.x/hv/channel_mgmt.c
+++ b/hv-rhel6.x/hv/channel_mgmt.c
@@ -428,8 +428,6 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
 			goto err_free_chan;
 	}
 	dev_type = hv_get_dev_type(newchannel);
-	if (dev_type == HV_NIC)
-		set_channel_signal_state(newchannel, HV_SIGNAL_POLICY_EXPLICIT);
 
 	init_vp_index(newchannel, dev_type);
 

--- a/hv-rhel6.x/hv/hyperv_vmbus.h
+++ b/hv-rhel6.x/hv/hyperv_vmbus.h
@@ -557,10 +557,9 @@ void hv_get_ringbuffer_available_space(struct hv_ring_buffer_info *inring_info,
 				       u32 *bytes_avail_toread,
 				       u32 *bytes_avail_towrite);
 
-int hv_ringbuffer_read(struct hv_ring_buffer_info *inring_info,
+int hv_ringbuffer_read(struct vmbus_channel *channel,
 		       void *buffer, u32 buflen, u32 *buffer_actual_len,
-		       u64 *requestid, bool *signal, bool raw);
-
+		       u64 *requestid, bool raw);
 
 void hv_ringbuffer_get_debuginfo(struct hv_ring_buffer_info *ring_info,
 			    struct hv_ring_buffer_debug_info *debug_info);

--- a/hv-rhel6.x/hv/hyperv_vmbus.h
+++ b/hv-rhel6.x/hv/hyperv_vmbus.h
@@ -548,10 +548,10 @@ int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
 
 void hv_ringbuffer_cleanup(struct hv_ring_buffer_info *ring_info);
 
-int hv_ringbuffer_write(struct hv_ring_buffer_info *ring_info,
-		    struct kvec *kv_list,
-		    u32 kv_count, bool *signal, bool lock,
-		    enum hv_signal_policy policy);
+int hv_ringbuffer_write(struct vmbus_channel *channel,
+			struct kvec *kv_list,
+			u32 kv_count, bool lock,
+			bool kick_q);
 
 void hv_get_ringbuffer_available_space(struct hv_ring_buffer_info *inring_info,
 				       u32 *bytes_avail_toread,

--- a/hv-rhel6.x/hv/include/linux/hyperv.h
+++ b/hv-rhel6.x/hv/include/linux/hyperv.h
@@ -1562,6 +1562,8 @@ extern bool vmbus_prep_negotiate_resp(struct icmsg_hdr *,
 
 void hv_process_channel_removal(struct vmbus_channel *channel, u32 relid);
 
+void vmbus_setevent(struct vmbus_channel *channel);
+
 /*
  * Negotiated version with the Host.
  */

--- a/hv-rhel6.x/hv/include/linux/hyperv.h
+++ b/hv-rhel6.x/hv/include/linux/hyperv.h
@@ -1597,10 +1597,11 @@ hv_get_ring_buffer(struct hv_ring_buffer_info *ring_info)
  *    there is room for the producer to send the pending packet.  
  */  
 
-static inline  bool hv_need_to_signal_on_read(struct hv_ring_buffer_info *rbi)
+static inline void hv_signal_on_read(struct vmbus_channel *channel)
 {
 	u32 cur_write_sz;
 	u32 pending_sz;
+	struct hv_ring_buffer_info *rbi = &channel->inbound;
 
 	/*  
 	 * Issue a full memory barrier before making the signaling decision.  
@@ -1618,14 +1619,14 @@ static inline  bool hv_need_to_signal_on_read(struct hv_ring_buffer_info *rbi)
 	pending_sz = READ_ONCE(rbi->ring_buffer->pending_send_sz);
 	/* If the other end is not blocked on write don't bother. */
 	if (pending_sz == 0)
-		return false;
+		return;
 
 	cur_write_sz = hv_get_bytes_to_write(rbi);
 
 	if (cur_write_sz >= pending_sz)
-		return true;
+		vmbus_setevent(channel);
 
-	return false;
+	return;
 }
 
 /*
@@ -1707,8 +1708,7 @@ static inline void commit_rd_index(struct vmbus_channel *channel)
 	rmb();
 	ring_info->ring_buffer->read_index = ring_info->priv_read_index;
 
-	if (hv_need_to_signal_on_read(ring_info))
-		vmbus_set_event(channel);
+	hv_signal_on_read(channel);
 }
 
 struct vmpipe_proto_header {

--- a/hv-rhel6.x/hv/ring_buffer.c
+++ b/hv-rhel6.x/hv/ring_buffer.c
@@ -75,13 +75,6 @@ static bool hv_need_to_signal(u32 old_write, struct hv_ring_buffer_info *rbi,
 	if (READ_ONCE(rbi->ring_buffer->interrupt_mask))
 		return false;
 
-	/*
-	 * When the client wants to control signaling,
-	 * we only honour the host interrupt mask.
-	 */
-	if (policy == HV_SIGNAL_POLICY_EXPLICIT)
-		return true;
-
 	/* check interrupt_mask before read_index */
 	rmb();
 	/*

--- a/hv-rhel6.x/hv/ring_buffer.c
+++ b/hv-rhel6.x/hv/ring_buffer.c
@@ -66,14 +66,25 @@ u32 hv_end_read(struct hv_ring_buffer_info *rbi)
  *	   once the ring buffer is empty, it will clear the
  *	   interrupt_mask and re-check to see if new data has
  *	   arrived.
+ *
+ * KYS: Oct. 30, 2016:
+ * It looks like Windows hosts have logic to deal with DOS attacks that
+ * can be triggered if it receives interrupts when it is not expecting
+ * the interrupt. The host expects interrupts only when the ring
+ * transitions from empty to non-empty (or full to non full on the
+ * guest to host ring).
+ * So, base the signaling decision solely on the ring state until the
+ * host logic is fixed.
  */
 
-static bool hv_need_to_signal(u32 old_write, struct hv_ring_buffer_info *rbi,
-			      enum hv_signal_policy policy)
+static void hv_signal_on_write(u32 old_write, struct vmbus_channel *channel,
+				bool kick_q)
 {
+	struct hv_ring_buffer_info *rbi = &channel->outbound;
+
 	mb();
 	if (READ_ONCE(rbi->ring_buffer->interrupt_mask))
-		return false;
+		return;
 
 	/* check interrupt_mask before read_index */
 	rmb();
@@ -82,9 +93,9 @@ static bool hv_need_to_signal(u32 old_write, struct hv_ring_buffer_info *rbi,
 	 * ring transitions from being empty to non-empty.
 	 */
 	if (old_write == READ_ONCE(rbi->ring_buffer->read_index))
-		return true;
+		vmbus_setevent(channel);
 
-	return false;
+	return;
 }
 
 /* Get the next write location for the specified ring buffer */
@@ -274,9 +285,9 @@ void hv_ringbuffer_cleanup(struct hv_ring_buffer_info *ring_info)
 }
 
 /* Write to the ring buffer */
-int hv_ringbuffer_write(struct hv_ring_buffer_info *outring_info,
-		    struct kvec *kv_list, u32 kv_count, bool *signal, bool lock,
-		    enum hv_signal_policy policy)
+int hv_ringbuffer_write(struct vmbus_channel *channel,
+			struct kvec *kv_list, u32 kv_count, bool lock,
+			bool kick_q)
 {
 	int i = 0;
 	u32 bytes_avail_towrite;
@@ -286,6 +297,7 @@ int hv_ringbuffer_write(struct hv_ring_buffer_info *outring_info,
 	u32 old_write;
 	u64 prev_indices = 0;
 	unsigned long flags = 0;
+	struct hv_ring_buffer_info *outring_info = &channel->outbound;
 
 	for (i = 0; i < kv_count; i++)
 		totalbytes_towrite += kv_list[i].iov_len;
@@ -337,7 +349,7 @@ int hv_ringbuffer_write(struct hv_ring_buffer_info *outring_info,
 	if (lock)
 		spin_unlock_irqrestore(&outring_info->ring_lock, flags);
 
-	*signal = hv_need_to_signal(old_write, outring_info, policy);
+	hv_signal_on_write(old_write, channel, kick_q);
 	return 0;
 }
 

--- a/hv-rhel6.x/hv/ring_buffer.c
+++ b/hv-rhel6.x/hv/ring_buffer.c
@@ -368,9 +368,9 @@ void hv_get_ringbuffer_available_space(struct hv_ring_buffer_info *inring_info,
 	spin_unlock_irqrestore(&inring_info->ring_lock, flags);
 }
 
-int hv_ringbuffer_read(struct hv_ring_buffer_info *inring_info,
+int hv_ringbuffer_read(struct vmbus_channel *channel,
 				     void *buffer, u32 buflen, u32 *buffer_actual_len,
-				     u64 *requestid, bool *signal, bool raw)
+				     u64 *requestid, bool raw)
 {
 	u32 bytes_avail_toread;
 	u32 next_read_location = 0;
@@ -379,6 +379,7 @@ int hv_ringbuffer_read(struct hv_ring_buffer_info *inring_info,
 	u32 offset;
 	u32 packetlen;
 	int ret = 0;
+	struct hv_ring_buffer_info *inring_info = &channel->inbound;
 
 	if (buflen <= 0)
 		return -EINVAL;
@@ -435,7 +436,7 @@ int hv_ringbuffer_read(struct hv_ring_buffer_info *inring_info,
 	/* Update the read index */
 	hv_set_next_read_location(inring_info, next_read_location);
 
-	*signal = hv_need_to_signal_on_read(inring_info);
+	hv_signal_on_read(channel);
 
 	return ret;
 }


### PR DESCRIPTION
  Drivers: hv: vmbus: Base host signaling strictly on the ring state
  Drivers: hv: vmbus: On write cleanup the logic to interrupt the host
  Drivers: hv: vmbus: On the read path cleanup the logic to interrupt the host
