### PR TITLE
RH6: Move some kernel code back under #ifdef __KERNEL

### DIFF
--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -633,7 +633,6 @@ static inline void skb_checksum_none_assert(struct sk_buff *skb)
 #endif
 }
 #endif
-#endif
 
 #if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,4))
 #include <linux/etherdevice.h>
@@ -650,5 +649,6 @@ static inline bool ether_addr_equal(const u8 *addr1, const u8 *addr2)
 }
 #endif
 
-#endif /*  end ifdef __KERNEL  */
+#endif /* end ifdef __KERNEL */
+#endif /* end LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 35) */
 #endif


### PR DESCRIPTION
This was causing some build breaks for user-mode daemons.