### PR TITLE
RH6/RH7: Fix TimeSync behavior

### DIFF
--- a/hv-rhel6.x/hv/arch/x86/hyperv/hv_init.c
+++ b/hv-rhel6.x/hv/arch/x86/hyperv/hv_init.c
@@ -112,6 +112,9 @@ static struct clocksource hyperv_cs_msr = {
 };
 
 static void *hypercall_pg;
+struct clocksource *hyperv_cs;
+EXPORT_SYMBOL_GPL(hyperv_cs);
+
 /*
  * This function is to be invoked early in the boot sequence after the
  * hypervisor has been detected.
@@ -161,14 +164,10 @@ void hyperv_init(void)
 		union hv_x64_msr_hypercall_contents tsc_msr;
 
 		tsc_pg = __vmalloc(PAGE_SIZE, GFP_KERNEL, PAGE_KERNEL);
-		if (!tsc_pg) {
-#if  (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,3))
-			clocksource_register(&hyperv_cs_msr);
-#else
-			clocksource_register_hz(&hyperv_cs_msr, NSEC_PER_SEC/100);
-#endif
-			return;
-		}
+		if (!tsc_pg)
+			goto register_msr_cs;
+
+		hyperv_cs = &hyperv_cs_tsc;
 
 		rdmsrl(HV_X64_MSR_REFERENCE_TSC, tsc_msr.as_uint64);
 
@@ -189,6 +188,8 @@ void hyperv_init(void)
 	 * the partition counter.
 	 */
 
+register_msr_cs:
+	hyperv_cs = &hyperv_cs_msr;
 	if (ms_hyperv.features & HV_X64_MSR_TIME_REF_COUNT_AVAILABLE)
 #if  (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,3))
 		clocksource_register(&hyperv_cs_msr);

--- a/hv-rhel6.x/hv/arch/x86/include/lis/asm/mshyperv.h
+++ b/hv-rhel6.x/hv/arch/x86/include/lis/asm/mshyperv.h
@@ -3,6 +3,7 @@
 
 #include <linux/types.h>
 #include <linux/interrupt.h>
+#include <linux/clocksource.h>
 #include <lis/asm/hyperv.h>
 
 /*
@@ -160,6 +161,8 @@ void hv_setup_kexec_handler(void (*handler)(void));
 void hv_remove_kexec_handler(void);
 void hv_setup_crash_handler(void (*handler)(struct pt_regs *regs));
 void hv_remove_crash_handler(void);
+
+extern struct clocksource *hyperv_cs;
 
 void hyperv_init(void);
 void hyperv_report_panic(struct pt_regs *regs);

--- a/hv-rhel6.x/hv/hv_util.c
+++ b/hv-rhel6.x/hv/hv_util.c
@@ -27,6 +27,7 @@
 #include <linux/sysctl.h>
 #include <linux/reboot.h>
 #include "include/linux/hyperv.h"
+#include <lis/asm/mshyperv.h>
 
 #include "hyperv_vmbus.h"
 
@@ -232,7 +233,7 @@ static void hv_set_host_time(struct work_struct *work)
 		 */
 		u64 current_tick;
 
-		rdmsrl(HV_X64_MSR_TIME_REF_COUNT, current_tick);
+		hv_get_current_tick(current_tick);
 		newtime += (current_tick - wrk->ref_time);
 	}
 	host_tns = (newtime - WLTIMEDELTA) * 100;

--- a/hv-rhel6.x/hv/hv_util.c
+++ b/hv-rhel6.x/hv/hv_util.c
@@ -54,6 +54,11 @@
 #define HB_MAJOR_1	1
 #define HB_VERSION_1	(HB_MAJOR_1 << 16 | HB_MINOR)
 
+static bool timesync_mode;
+module_param(timesync_mode, bool, 0644);
+MODULE_PARM_DESC(timesync_mode,
+       "If set, continuously discipline the local clock with timesync.");
+
 static int sd_srv_version;
 static int ts_srv_version;
 static int hb_srv_version;
@@ -247,11 +252,14 @@ static void hv_set_host_time(struct work_struct *work)
  *
  * ICTIMESYNCFLAG_SAMPLE bit indicates a time sample from host. This is
  * typically used as a hint to the guest. The guest is under no obligation
- * to discipline the clock.
+ * to discipline the clock. If timesync_mode is set, then we always discipline
+ * the clock. Otherwise, we only discipline the clock for the first 50 samples
+ * to do initial time setting.
  */
 static struct adj_time_work  wrk;
 static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 flags)
 {
+	static int remaining_samples = 50;
 
 	/*
 	 * This check is safe since we are executing in the
@@ -264,7 +272,14 @@ static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 flags)
 	wrk.host_time = hosttime;
 	wrk.ref_time = reftime;
 	wrk.flags = flags;
-	if ((flags & (ICTIMESYNCFLAG_SYNC | ICTIMESYNCFLAG_SAMPLE)) != 0) {
+
+	if (timesync_mode || (flags & ICTIMESYNCFLAG_SYNC) != 0) {
+		schedule_work(&wrk.work);
+		return;
+	}
+
+	if ((flags & ICTIMESYNCFLAG_SAMPLE) != 0 && remaining_samples > 0) {
+		remaining_samples--;
 		schedule_work(&wrk.work);
 	}
 }
@@ -294,9 +309,11 @@ static void timesync_onchannelcallback(void *context)
 						fw_versions, FW_VER_COUNT,
 						ts_versions, TS_VER_COUNT,
 						NULL, &ts_srv_version)) {
-				pr_info("TimeSync IC version %d.%d\n",
+				pr_info("TimeSync IC version %d.%d. Mode: %s\n",
 					ts_srv_version >> 16,
-					ts_srv_version & 0xFFFF);
+					ts_srv_version & 0xFFFF,
+					timesync_mode ?
+					"Always" : "Only On Init");
 			}
 		} else {
 			if (ts_srv_version > TS_VERSION_3) {

--- a/hv-rhel7.x/hv/arch/x86/include/lis/asm/mshyperv.h
+++ b/hv-rhel7.x/hv/arch/x86/include/lis/asm/mshyperv.h
@@ -3,6 +3,7 @@
 
 #include <linux/types.h>
 #include <linux/interrupt.h>
+#include <linux/clocksource.h>
 #include <lis/asm/hyperv.h>
 
 /*
@@ -162,6 +163,8 @@ void hv_setup_crash_handler(void (*handler)(struct pt_regs *regs));
 void hv_remove_crash_handler(void);
 
 #if IS_ENABLED(CONFIG_HYPERV)
+extern struct clocksource *hyperv_cs;
+
 void hyperv_init(void);
 void hyperv_report_panic(struct pt_regs *regs);
 bool hv_is_hypercall_page_setup(void);

--- a/hv-rhel7.x/hv/hv_util.c
+++ b/hv-rhel7.x/hv/hv_util.c
@@ -27,6 +27,7 @@
 #include <linux/sysctl.h>
 #include <linux/reboot.h>
 #include "include/linux/hyperv.h"
+#include <lis/asm/mshyperv.h>
 
 #include "hyperv_vmbus.h"
 
@@ -227,7 +228,7 @@ static void hv_set_host_time(struct work_struct *work)
 		 */
 		u64 current_tick;
 
-		rdmsrl(HV_X64_MSR_TIME_REF_COUNT, current_tick);
+		hv_get_current_tick(current_tick);
 		newtime += (current_tick - wrk->ref_time);
 	}
 	host_tns = (newtime - WLTIMEDELTA) * 100;

--- a/hv-rhel7.x/hv/hv_util.c
+++ b/hv-rhel7.x/hv/hv_util.c
@@ -27,6 +27,8 @@
 #include <linux/sysctl.h>
 #include <linux/reboot.h>
 #include "include/linux/hyperv.h"
+#include <linux/clockchips.h>
+#include <linux/ptp_clock_kernel.h>
 #include <lis/asm/mshyperv.h>
 
 #include "hyperv_vmbus.h"
@@ -210,29 +212,15 @@ struct adj_time_work {
 
 static void hv_set_host_time(struct work_struct *work)
 {
-	struct adj_time_work	*wrk;
-	s64 host_tns;
-	u64 newtime;
+	struct adj_time_work *wrk;
 	struct timespec64 host_ts;
+	u64 reftime, newtime;
 
 	wrk = container_of(work, struct adj_time_work, work);
 
-	newtime = wrk->host_time;
-	if (ts_srv_version > TS_VERSION_3) {
-		/*
-		 * Some latency has been introduced since Hyper-V generated
-		 * its time sample. Take that latency into account before
-		 * using TSC reference time sample from Hyper-V.
-		 *
-		 * This sample is given by TimeSync v4 and above hosts.
-		 */
-		u64 current_tick;
-
-		hv_get_current_tick(current_tick);
-		newtime += (current_tick - wrk->ref_time);
-	}
-	host_tns = (newtime - WLTIMEDELTA) * 100;
-	host_ts = ns_to_timespec64(host_tns);
+	reftime = hyperv_cs->read(hyperv_cs);
+	newtime = wrk->host_time + (reftime - wrk->ref_time);
+	host_ts = ns_to_timespec64((newtime - WLTIMEDELTA) * 100);
 
 	do_settimeofday64(&host_ts);
 }
@@ -251,22 +239,64 @@ static void hv_set_host_time(struct work_struct *work)
  * to discipline the clock.
  */
 static struct adj_time_work  wrk;
-static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 flags)
+
+/*
+ * The last time sample, received from the host. PTP device responds to
+ * requests by using this data and the current partition-wide time reference
+ * count.
+ */
+static struct {
+	u64				host_time;
+	u64				ref_time;
+#ifdef NOTYET
+	struct system_time_snapshot	snap;
+#endif
+	spinlock_t			lock;
+} host_ts;
+
+static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 adj_flags)
 {
+	unsigned long flags;
+	u64 cur_reftime;
 
 	/*
 	 * This check is safe since we are executing in the
 	 * interrupt context and time synch messages are always
 	 * delivered on the same CPU.
 	 */
-	if (work_pending(&wrk.work))
-		return;
+	if (adj_flags & ICTIMESYNCFLAG_SYNC) {
+		/* Queue a job to do do_settimeofday64() */
+		if (work_pending(&wrk.work))
+			return;
 
-	wrk.host_time = hosttime;
-	wrk.ref_time = reftime;
-	wrk.flags = flags;
-	if ((flags & (ICTIMESYNCFLAG_SYNC | ICTIMESYNCFLAG_SAMPLE)) != 0) {
+		wrk.host_time = hosttime;
+		wrk.ref_time = reftime;
+		wrk.flags = adj_flags;
 		schedule_work(&wrk.work);
+	} else {
+		/*
+		 * Save the adjusted time sample from the host and the snapshot
+		 * of the current system time for PTP device.
+		 */
+		spin_lock_irqsave(&host_ts.lock, flags);
+
+		cur_reftime = hyperv_cs->read(hyperv_cs);
+		host_ts.host_time = hosttime;
+		host_ts.ref_time = cur_reftime;
+#ifdef NOTYET
+		ktime_get_snapshot(&host_ts.snap);
+#endif
+
+		/*
+		 * TimeSync v4 messages contain reference time (guest's Hyper-V
+		 * clocksource read when the time sample was generated), we can
+		 * improve the precision by adding the delta between now and the
+		 * time of generation.
+		 */
+		if (ts_srv_version > TS_VERSION_3)
+			host_ts.host_time += (cur_reftime - reftime);
+
+		spin_unlock_irqrestore(&host_ts.lock, flags);
 	}
 }
 
@@ -478,14 +508,117 @@ static  struct hv_driver util_drv = {
 	.remove =  util_remove,
 };
 
+static int hv_ptp_enable(struct ptp_clock_info *info,
+			 struct ptp_clock_request *request, int on)
+{
+	return -EOPNOTSUPP;
+}
+
+static int hv_ptp_settime(struct ptp_clock_info *p, const struct timespec64 *ts)
+{
+	return -EOPNOTSUPP;
+}
+
+static int hv_ptp_adjfreq(struct ptp_clock_info *ptp, s32 delta)
+{
+	return -EOPNOTSUPP;
+}
+static int hv_ptp_adjtime(struct ptp_clock_info *ptp, s64 delta)
+{
+	return -EOPNOTSUPP;
+}
+
+static int hv_ptp_gettime(struct ptp_clock_info *info, struct timespec64 *ts)
+{
+	unsigned long flags;
+	u64 newtime, reftime;
+
+	spin_lock_irqsave(&host_ts.lock, flags);
+	reftime = hyperv_cs->read(hyperv_cs);
+	newtime = host_ts.host_time + (reftime - host_ts.ref_time);
+	*ts = ns_to_timespec64((newtime - WLTIMEDELTA) * 100);
+	spin_unlock_irqrestore(&host_ts.lock, flags);
+
+	return 0;
+}
+
+#ifdef NOTYET
+static int hv_ptp_get_syncdevicetime(ktime_t *device,
+				     struct system_counterval_t *system,
+				     void *ctx)
+{
+	system->cs = hyperv_cs;
+	system->cycles = host_ts.ref_time;
+	*device = ns_to_ktime((host_ts.host_time - WLTIMEDELTA) * 100);
+
+	return 0;
+}
+
+static int hv_ptp_getcrosststamp(struct ptp_clock_info *ptp,
+				 struct system_device_crosststamp *xtstamp)
+{
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&host_ts.lock, flags);
+
+	/*
+	 * host_ts contains the last time sample from the host and the snapshot
+	 * of system time. We don't need to calculate the time delta between
+	 * the reception and now as get_device_system_crosststamp() does the
+	 * required interpolation.
+	 */
+	ret = get_device_system_crosststamp(hv_ptp_get_syncdevicetime,
+					    NULL, &host_ts.snap, xtstamp);
+
+	spin_unlock_irqrestore(&host_ts.lock, flags);
+
+	return ret;
+}
+#endif
+
+static struct ptp_clock_info ptp_hyperv_info = {
+	.name		= "hyperv",
+	.enable         = hv_ptp_enable,
+	.adjtime        = hv_ptp_adjtime,
+	.adjfreq        = hv_ptp_adjfreq,
+	.gettime        = hv_ptp_gettime,
+#ifdef NOTYET
+	.getcrosststamp = hv_ptp_getcrosststamp,
+#endif
+	.settime        = hv_ptp_settime,
+	.owner		= THIS_MODULE,
+};
+
+static struct ptp_clock *hv_ptp_clock;
+
 static int hv_timesync_init(struct hv_util_service *srv)
 {
+	/* TimeSync requires Hyper-V clocksource. */
+	if (!hyperv_cs)
+		return -ENODEV;
+
 	INIT_WORK(&wrk.work, hv_set_host_time);
+
+	/*
+	 * ptp_clock_register() returns NULL when CONFIG_PTP_1588_CLOCK is
+	 * disabled but the driver is still useful without the PTP device
+	 * as it still handles the ICTIMESYNCFLAG_SYNC case.
+	 */
+	hv_ptp_clock = ptp_clock_register(&ptp_hyperv_info, NULL);
+	if (IS_ERR_OR_NULL(hv_ptp_clock)) {
+		pr_err("cannot register PTP clock: %ld\n",
+		       PTR_ERR(hv_ptp_clock));
+		hv_ptp_clock = NULL;
+	}
+
 	return 0;
 }
 
 static void hv_timesync_deinit(void)
 {
+	if (hv_ptp_clock)
+		ptp_clock_unregister(hv_ptp_clock);
 	cancel_work_sync(&wrk.work);
 }
 


### PR DESCRIPTION
Introduce PTP-based TimeSync config in RH7. On RH6, PTP doesn't exist, so we provide a module param to enable TimeSync instead.