### PR TITLE
RH7: netvsc: use napi_consume_skb

### DIFF
--- a/hv-rhel7.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel7.x/hv/include/linux/hv_compat.h
@@ -73,6 +73,10 @@
 #define skb_vlan_tag_present(__skb)	((__skb)->vlan_tci & VLAN_TAG_PRESENT)
 #endif
 
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,3))
+#define napi_consume_skb(skb, budget)     dev_consume_skb_any(skb)
+#endif
+
 #if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,3))
 static inline struct page *skb_frag_page(const skb_frag_t *frag)
 {


### PR DESCRIPTION
netvsc: use napi_consume_skb
f9645430ef5f53ddf0ddd481e9f70f6fce7ccff2

This allows using deferred skb freeing and with NAPI. And get buffer
recycling.
