### PR TITLE
RH6: RCU commits cleanup

### DIFF
--- a/hv-rhel6.x/hv/channel_mgmt.c
+++ b/hv-rhel6.x/hv/channel_mgmt.c
@@ -352,7 +352,7 @@ static struct vmbus_channel *alloc_channel(void)
 static void free_channel(struct vmbus_channel *channel)
 {
 	tasklet_kill(&channel->callback_event);
-	kfree_rcu(channel, rcu);
+	kfree(channel);
 }
 
 static void percpu_channel_enq(void *arg)
@@ -361,14 +361,14 @@ static void percpu_channel_enq(void *arg)
 	struct hv_per_cpu_context *hv_cpu
 		= this_cpu_ptr(hv_context.cpu_context);
 
-	list_add_tail_rcu(&channel->percpu_list, &hv_cpu->chan_list);
+	list_add_tail(&channel->percpu_list, &hv_cpu->chan_list);
 }
 
 static void percpu_channel_deq(void *arg)
 {
 	struct vmbus_channel *channel = arg;
 
-	list_del_rcu(&channel->percpu_list);
+	list_del(&channel->percpu_list);
 }
 
 static void vmbus_release_relid(u32 relid)

--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -724,9 +724,6 @@ struct net_device_context {
 	u32 speed;
 	struct netvsc_ethtool_stats eth_stats;
 
-	/* the device is going away */
-	bool start_remove;
-
 	/* State to manage the associated VF interface. */
 	struct net_device *vf_netdev;
 	bool vf_inject;

--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -724,6 +724,9 @@ struct net_device_context {
 	u32 speed;
 	struct netvsc_ethtool_stats eth_stats;
 
+	/* the device is going away */
+	bool start_remove;
+
 	/* State to manage the associated VF interface. */
 	struct net_device *vf_netdev;
 	bool vf_inject;

--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -698,7 +698,7 @@ struct net_device_context {
 	/* point back to our device context */
 	struct hv_device *device_ctx;
 	/* netvsc_device */
-	struct netvsc_device __rcu *nvdev;
+	struct netvsc_device *nvdev;
 	/* reconfigure work */
 	struct delayed_work dwork;
 	/* last reconfig time */
@@ -802,8 +802,6 @@ struct netvsc_device {
 	atomic_t open_cnt;
 
 	struct netvsc_channel chan_table[VRSS_CHANNEL_MAX];
-
-	struct rcu_head rcu;
 };
 
 static inline struct netvsc_device *

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -675,6 +675,14 @@ static inline u32 ethtool_rxfh_indir_default(u32 index, u32 n_rx_rings)
 }
 #endif
 
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,4))
+#define rtnl_dereference(ptr) (ptr)
+
+#ifdef rcu_dereference_rtnl
+#define rcu_dereference_rtnl(p)  rcu_dereference(p)
+#endif
+#endif
+
 #ifndef NAPI_POLL_WEIGHT
 #define NAPI_POLL_WEIGHT 64
 #endif

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -677,10 +677,6 @@ static inline u32 ethtool_rxfh_indir_default(u32 index, u32 n_rx_rings)
 
 #if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,4))
 #define rtnl_dereference(ptr) (ptr)
-
-#ifdef rcu_dereference_rtnl
-#define rcu_dereference_rtnl(p)  rcu_dereference(p)
-#endif
 #endif
 
 #ifndef NAPI_POLL_WEIGHT

--- a/hv-rhel6.x/hv/include/linux/hyperv.h
+++ b/hv-rhel6.x/hv/include/linux/hyperv.h
@@ -891,13 +891,6 @@ struct vmbus_channel {
 	 * link up channels based on their CPU affinity.
 	 */
 	struct list_head percpu_list;
-
-	/*
-	 * Defer freeing channel until after all cpu's have
-	 * gone through grace period.
-	 */
-	struct rcu_head rcu;
-
 	/*
 	 * For performance critical channels (storage, networking
 	 * etc,), Hyper-V has a mechanism to enhance the throughput

--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -634,6 +634,7 @@ static void netvsc_send_tx_complete(struct netvsc_device *net_device,
 {
 	struct sk_buff *skb = (struct sk_buff *)(unsigned long)desc->trans_id;
 	struct net_device *ndev = hv_get_drvdata(device);
+	struct net_device_context *net_device_ctx = netdev_priv(ndev);
 	struct vmbus_channel *channel = device->channel;
 	struct netvsc_stats *tx_stats;
 	u16 q_idx = 0;
@@ -668,6 +669,7 @@ static void netvsc_send_tx_complete(struct netvsc_device *net_device,
 		wake_up(&net_device->wait_drain);
 
 	if (netif_tx_queue_stopped(netdev_get_tx_queue(ndev, q_idx)) &&
+	    !net_device_ctx->start_remove &&
 	    (hv_ringbuf_avail_percent(&channel->outbound) > RING_AVAIL_PERCENT_HIWATER ||
 	     queue_sends < 1))
 		netif_tx_wake_queue(netdev_get_tx_queue(ndev, q_idx));
@@ -1353,6 +1355,8 @@ int netvsc_device_add(struct hv_device *device,
 	/* Writing nvdev pointer unlocks netvsc_send(), make sure chn_table is
 	 * populated.
 	 */
+	wmb();
+
 	rcu_assign_pointer(net_device_ctx->nvdev, net_device);
 
 	/* Connect with the NetVsp */

--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -628,7 +628,6 @@ static void netvsc_send_tx_complete(struct netvsc_device *net_device,
 {
 	struct sk_buff *skb = (struct sk_buff *)(unsigned long)desc->trans_id;
 	struct net_device *ndev = hv_get_drvdata(device);
-	struct net_device_context *net_device_ctx = netdev_priv(ndev);
 	struct vmbus_channel *channel = device->channel;
 	struct netvsc_stats *tx_stats;
 	u16 q_idx = 0;
@@ -663,7 +662,6 @@ static void netvsc_send_tx_complete(struct netvsc_device *net_device,
 		wake_up(&net_device->wait_drain);
 
 	if (netif_tx_queue_stopped(netdev_get_tx_queue(ndev, q_idx)) &&
-	    !net_device_ctx->start_remove &&
 	    (hv_ringbuf_avail_percent(&channel->outbound) > RING_AVAIL_PERCENT_HIWATER ||
 	     queue_sends < 1))
 		netif_tx_wake_queue(netdev_get_tx_queue(ndev, q_idx));
@@ -1349,8 +1347,6 @@ int netvsc_device_add(struct hv_device *device,
 	/* Writing nvdev pointer unlocks netvsc_send(), make sure chn_table is
 	 * populated.
 	 */
-	wmb();
-
 	net_device_ctx->nvdev = net_device;
 
 	/* Connect with the NetVsp */

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -924,7 +924,8 @@ static void *netvsc_get_stats64(struct net_device *net,
 				struct rtnl_link_stats64 *t)
 {
 	struct net_device_context *ndev_ctx = netdev_priv(net);
-	struct netvsc_device *nvdev = rcu_dereference_rtnl(ndev_ctx->nvdev);
+
+	struct netvsc_device *nvdev = rcu_dereference(ndev_ctx->nvdev);
 	int i;
 
 	if (!nvdev)

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -65,7 +65,7 @@ static void do_set_multicast(struct work_struct *w)
 		container_of(w, struct net_device_context, work);
 	struct hv_device *device_obj = ndevctx->device_ctx;
 	struct net_device *ndev = hv_get_drvdata(device_obj);
-	struct netvsc_device *nvdev = rcu_dereference(ndevctx->nvdev);
+	struct netvsc_device *nvdev = ndevctx->nvdev;
 	struct rndis_device *rdev;
 
 	if (!nvdev)
@@ -119,7 +119,7 @@ static int netvsc_open(struct net_device *net)
 static int netvsc_close(struct net_device *net)
 {
 	struct net_device_context *net_device_ctx = netdev_priv(net);
-	struct netvsc_device *nvdev = rtnl_dereference(net_device_ctx->nvdev);
+	struct netvsc_device *nvdev = net_device_ctx->nvdev;
 	int ret;
 	u32 aread, awrite, i, msec = 10, retry = 0, retry_max = 20;
 	struct vmbus_channel *chn;
@@ -667,7 +667,7 @@ int netvsc_recv_callback(struct net_device *net,
 		}
 
 		/*
-		 * Inject this packet into the VF interface.
+		 * Inject this packet into the VF inerface.
 		 * On Hyper-V, multicast and brodcast packets
 		 * are only delivered on the synthetic interface
 		 * (after subjecting these to policy filters on
@@ -730,7 +730,7 @@ static void netvsc_get_channels(struct net_device *net,
 				struct ethtool_channels *channel)
 {
 	struct net_device_context *net_device_ctx = netdev_priv(net);
-	struct netvsc_device *nvdev = rtnl_dereference(net_device_ctx->nvdev);
+	struct netvsc_device *nvdev = net_device_ctx->nvdev;
 
 	if (nvdev) {
 		channel->max_combined	= nvdev->max_chn;
@@ -767,7 +767,7 @@ static int netvsc_set_channels(struct net_device *net,
 {
 	struct net_device_context *net_device_ctx = netdev_priv(net);
 	struct hv_device *dev = net_device_ctx->device_ctx;
-	struct netvsc_device *nvdev = rtnl_dereference(net_device_ctx->nvdev);
+	struct netvsc_device *nvdev = net_device_ctx->nvdev;
 	unsigned int count = channels->combined_count;
 	bool was_running;
 	int ret;
@@ -872,7 +872,7 @@ static int netvsc_set_settings(struct net_device *dev, struct ethtool_cmd *cmd)
 static int netvsc_change_mtu(struct net_device *ndev, int mtu)
 {
 	struct net_device_context *ndevctx = netdev_priv(ndev);
-	struct netvsc_device *nvdev = rtnl_dereference(ndevctx->nvdev);
+	struct netvsc_device *nvdev = ndevctx->nvdev;
 	struct hv_device *hdev = ndevctx->device_ctx;
 	struct netvsc_device_info device_info;
 	int limit = ETH_DATA_LEN;
@@ -931,7 +931,7 @@ static void *netvsc_get_stats64(struct net_device *net,
 {
 	struct net_device_context *ndev_ctx = netdev_priv(net);
 
-	struct netvsc_device *nvdev = rcu_dereference(ndev_ctx->nvdev);
+	struct netvsc_device *nvdev = ndev_ctx->nvdev;
 	int i;
 
 	if (!nvdev)
@@ -1017,10 +1017,7 @@ static const struct {
 static int netvsc_get_sset_count(struct net_device *dev, int string_set)
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *nvdev = rcu_dereference(ndc->nvdev);
-
-	if (!nvdev)
-		return -ENODEV;
+	struct netvsc_device *nvdev = ndc->nvdev;
 
 	switch (string_set) {
 	case ETH_SS_STATS:
@@ -1034,15 +1031,12 @@ static void netvsc_get_ethtool_stats(struct net_device *dev,
 				     struct ethtool_stats *stats, u64 *data)
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *nvdev = rcu_dereference(ndc->nvdev);
+	struct netvsc_device *nvdev = ndc->nvdev;
 	const void *nds = &ndc->eth_stats;
 	const struct netvsc_stats *qstats;
 	unsigned int start;
 	u64 packets, bytes;
 	int i, j;
-
-	if (!nvdev)
-		return;
 
 	for (i = 0; i < NETVSC_GLOBAL_STATS_LEN; i++)
 		data[i] = *(unsigned long *)(nds + netvsc_stats[i].offset);
@@ -1072,12 +1066,9 @@ static void netvsc_get_ethtool_stats(struct net_device *dev,
 static void netvsc_get_strings(struct net_device *dev, u32 stringset, u8 *data)
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *nvdev = rcu_dereference(ndc->nvdev);
+	struct netvsc_device *nvdev = ndc->nvdev;
 	u8 *p = data;
 	int i;
-
-	if (!nvdev)
-		return;
 
 	switch (stringset) {
 	case ETH_SS_STATS:
@@ -1138,10 +1129,7 @@ netvsc_get_rxnfc(struct net_device *dev, struct ethtool_rxnfc *info,
 
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *nvdev = rcu_dereference(ndc->nvdev);
-
-	if (!nvdev)
-		return -ENODEV;
+	struct netvsc_device *nvdev = ndc->nvdev;
 
 	switch (info->cmd) {
 	case ETHTOOL_GRXRINGS:
@@ -1178,12 +1166,9 @@ static int netvsc_get_rxfh(struct net_device *dev, u32 *indir, u8 *key,
 			   u8 *hfunc)
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *ndev = rcu_dereference(ndc->nvdev);
+	struct netvsc_device *ndev = ndc->nvdev;
 	struct rndis_device *rndis_dev = ndev->extension;
 	int i;
-
-	if (!ndev)
-		return -ENODEV;
 
 	if (hfunc)
 		*hfunc = ETH_RSS_HASH_TOP;	/* Toeplitz */
@@ -1203,12 +1188,9 @@ static int netvsc_set_rxfh(struct net_device *dev, const u32 *indir,
 			   const u8 *key, const u8 hfunc)
 {
 	struct net_device_context *ndc = netdev_priv(dev);
-	struct netvsc_device *ndev = rtnl_dereference(ndc->nvdev);
+	struct netvsc_device *ndev = ndc->nvdev;
 	struct rndis_device *rndis_dev = ndev->extension;
 	int i;
-
-	if (!ndev)
-		return -ENODEV;
 
 	if (hfunc != ETH_RSS_HASH_NO_CHANGE && hfunc != ETH_RSS_HASH_TOP)
 		return -EOPNOTSUPP;
@@ -1293,7 +1275,7 @@ static void netvsc_link_change(struct work_struct *w)
 	if (ndev_ctx->start_remove)
 		goto out_unlock;
 
-	net_device = rtnl_dereference(ndev_ctx->nvdev);
+	net_device = ndev_ctx->nvdev;
 	rdev = net_device->extension;
 
 	next_reconfig = ndev_ctx->last_reconfig + LINKCHANGE_INT;
@@ -1449,7 +1431,7 @@ static int netvsc_register_vf(struct net_device *vf_netdev)
 		return NOTIFY_DONE;
 
 	net_device_ctx = netdev_priv(ndev);
-	netvsc_dev = rtnl_dereference(net_device_ctx->nvdev);
+	netvsc_dev = net_device_ctx->nvdev;
 	if (!netvsc_dev || net_device_ctx->vf_netdev)
 		return NOTIFY_DONE;
 
@@ -1489,7 +1471,7 @@ static int netvsc_vf_up(struct net_device *vf_netdev)
 		return NOTIFY_DONE;
 
 	net_device_ctx = netdev_priv(ndev);
-	netvsc_dev = rtnl_dereference(net_device_ctx->nvdev);
+	netvsc_dev = net_device_ctx->nvdev;
 
 	if (!net_device_ctx->synthetic_data_path)
 		return NOTIFY_DONE;
@@ -1539,7 +1521,7 @@ static int netvsc_vf_down(struct net_device *vf_netdev, bool rndis_close)
 		return NOTIFY_DONE;
 
 	net_device_ctx = netdev_priv(ndev);
-	netvsc_dev = rtnl_dereference(net_device_ctx->nvdev);
+	netvsc_dev = net_device_ctx->nvdev;
 
 	if (net_device_ctx->synthetic_data_path)
 		return NOTIFY_DONE;
@@ -1661,7 +1643,6 @@ static int netvsc_probe(struct hv_device *dev,
 
 	net->vlan_features = net->features;
 
-	/* RCU not necessary here, device not registered */
 	nvdev = net_device_ctx->nvdev;
 	netif_set_real_num_tx_queues(net, nvdev->num_chn);
 #ifdef NOTYET

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -780,7 +780,7 @@ static int netvsc_set_channels(struct net_device *net,
 	if (count > net->num_tx_queues || count > net->num_rx_queues)
 		return -EINVAL;
 
-	if (net_device_ctx->start_remove || !nvdev || nvdev->destroy)
+	if (!nvdev || nvdev->destroy)
 		return -ENODEV;
 
 	if (nvdev->nvsp_version < NVSP_PROTOCOL_VERSION_5)
@@ -796,7 +796,6 @@ static int netvsc_set_channels(struct net_device *net,
 			return ret;
 	}
 
-	net_device_ctx->start_remove = true;
 	rndis_filter_device_remove(dev, nvdev);
 
 	ret = netvsc_set_queues(net, dev, count);
@@ -804,8 +803,6 @@ static int netvsc_set_channels(struct net_device *net,
 		nvdev->num_chn = count;
 	else
 		netvsc_set_queues(net, dev, nvdev->num_chn);
-
-	net_device_ctx->start_remove = false;
 
 	if (was_running)
 		ret = netvsc_open(net);
@@ -879,7 +876,7 @@ static int netvsc_change_mtu(struct net_device *ndev, int mtu)
 	bool was_running;
 	int ret = 0;
 
-	if (ndevctx->start_remove || !nvdev || nvdev->destroy)
+	if (!nvdev || nvdev->destroy)
 		return -ENODEV;
 
 	if (nvdev->nvsp_version >= NVSP_PROTOCOL_VERSION_2)
@@ -900,7 +897,6 @@ static int netvsc_change_mtu(struct net_device *ndev, int mtu)
 	device_info.num_chn = nvdev->num_chn;
 	device_info.max_num_vrss_chns = nvdev->num_chn;
 
-	ndevctx->start_remove = true;
 	rndis_filter_device_remove(hdev, nvdev);
 
 	/* 'nvdev' has been freed in rndis_filter_device_remove() ->
@@ -913,8 +909,6 @@ static int netvsc_change_mtu(struct net_device *ndev, int mtu)
 	ndev->mtu = mtu;
 
 	rndis_filter_device_add(hdev, &device_info);
-
-	ndevctx->start_remove = false;
 
 	if (was_running)
 		ret = netvsc_open(ndev);
@@ -1272,10 +1266,10 @@ static void netvsc_link_change(struct work_struct *w)
 	unsigned long flags, next_reconfig, delay;
 
 	rtnl_lock();
-	if (ndev_ctx->start_remove)
+	net_device = rtnl_dereference(ndev_ctx->nvdev);
+	if (!net_device)
 		goto out_unlock;
 
-	net_device = ndev_ctx->nvdev;
 	rdev = net_device->extension;
 
 	next_reconfig = ndev_ctx->last_reconfig + LINKCHANGE_INT;
@@ -1599,8 +1593,6 @@ static int netvsc_probe(struct hv_device *dev,
 
 	hv_set_drvdata(dev, net);
 
-	net_device_ctx->start_remove = false;
-
 	net_device_ctx->synthetic_data_path = true;
 
 	INIT_DELAYED_WORK(&net_device_ctx->dwork, netvsc_link_change);
@@ -1676,26 +1668,20 @@ static int netvsc_remove(struct hv_device *dev)
 
 	ndev_ctx = netdev_priv(net);
 
-	/* Avoid racing with netvsc_change_mtu()/netvsc_set_channels()
-	 * removing the device.
-	 */
-	rtnl_lock();
-	ndev_ctx->start_remove = true;
-	rtnl_unlock();
+	netif_device_detach(net);
 
 	cancel_delayed_work_sync(&ndev_ctx->dwork);
 	cancel_work_sync(&ndev_ctx->work);
 
-	/* Stop outbound asap */
-	netif_tx_disable(net);
-
-	unregister_netdev(net);
-
 	/*
 	 * Call to the vsc driver to let it know that the device is being
-	 * removed
+	 * removed. Also blocks mtu and channel changes.
 	 */
+	rtnl_lock();
 	rndis_filter_device_remove(dev, ndev_ctx->nvdev);
+	rtnl_unlock();
+
+	unregister_netdev(net);
 
 	hv_set_drvdata(dev, NULL);
 

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -924,8 +924,7 @@ static void *netvsc_get_stats64(struct net_device *net,
 				struct rtnl_link_stats64 *t)
 {
 	struct net_device_context *ndev_ctx = netdev_priv(net);
-
-	struct netvsc_device *nvdev = ndev_ctx->nvdev;
+	struct netvsc_device *nvdev = rcu_dereference_rtnl(ndev_ctx->nvdev);
 	int i;
 
 	if (!nvdev)

--- a/hv-rhel6.x/hv/vmbus_drv.c
+++ b/hv-rhel6.x/hv/vmbus_drv.c
@@ -658,10 +658,8 @@ static void vmbus_chan_sched(struct hv_per_cpu_context *hv_cpu)
 		if (relid == 0)
 			continue;
 
-		rcu_read_lock();
-
 		/* Find channel based on relid */
-		list_for_each_entry_rcu(channel, &hv_cpu->chan_list, percpu_list) {
+		list_for_each_entry(channel, &hv_cpu->chan_list, percpu_list) {
 			if (channel->offermsg.child_relid != relid)
 				continue;
 
@@ -677,8 +675,6 @@ static void vmbus_chan_sched(struct hv_per_cpu_context *hv_cpu)
 				tasklet_schedule(&channel->callback_event);
 			}
 		}
-
-		rcu_read_unlock();
 	}
 }
 


### PR DESCRIPTION
Masked functions that are present only in RHEL 6.4 and reverted commits that cannot be ported on older versions (<6.4).