### PR TITLE
RH7: hv_netvsc: Fix the queue index computation in forwarding case

### DIFF
--- a/hv-rhel7.x/hv/hyperv_net.h
+++ b/hv-rhel7.x/hv/hyperv_net.h
@@ -636,7 +636,7 @@ struct nvsp_message {
 
 #define NETVSC_PACKET_SIZE                      4096
 
-#define VRSS_SEND_TAB_SIZE 16
+#define VRSS_SEND_TAB_SIZE 16  /* must be power of 2 */
 #define VRSS_CHANNEL_MAX 64
 #define VRSS_CHANNEL_DEFAULT 8
 


### PR DESCRIPTION
hv_netvsc: Fix the queue index computation in forwarding case
8db91f6a9b2ff2bb5355ad11c668fe63eb8ae0c3

If the outgoing skb has a RX queue mapping available, we use the queue
number directly, other than put it through Send Indirection Table.
