### PR TITLE
RH7: Add some missing backports that were missed in last PCI patch

### DIFF
--- a/hv-rhel7.x/hv/arch/x86/include/uapi/lis/asm/hyperv.h
+++ b/hv-rhel7.x/hv/arch/x86/include/uapi/lis/asm/hyperv.h
@@ -151,6 +151,12 @@
 #define HV_X64_DEPRECATING_AEOI_RECOMMENDED	(1 << 9)
 
 /*
+ * HV_VP_SET available
+ */
+#define HV_X64_EX_PROCESSOR_MASKS_RECOMMENDED	(1 < 11)
+
+
+/*
  * Crash notification flag.
  */
 #define HV_CRASH_CTL_CRASH_NOTIFY (1ULL << 63)


### PR DESCRIPTION
This updates the backporting that was started in commit:
fe4bfc622be20380da0da02c81568a582304a512