### PR TITLE
RH6 & RH7 storvsc upstream commits

### DIFF
--- a/hv-rhel6.x/hv/storvsc_drv.c
+++ b/hv-rhel6.x/hv/storvsc_drv.c
@@ -1530,8 +1530,6 @@ static void storvsc_on_channel_callback(void *context)
 			break;
 		}
 	} while (1);
-
-	return;
 }
 
 static int storvsc_connect_to_vsp(struct hv_device *device, u32 ring_size,

--- a/hv-rhel6.x/hv/storvsc_drv.c
+++ b/hv-rhel6.x/hv/storvsc_drv.c
@@ -1153,7 +1153,7 @@ static int storvsc_channel_init(struct hv_device *device, bool is_fc)
 	 * We will however populate all the slots to evenly distribute
 	 * the load.
 	 */
-	stor_device->stor_chns = kzalloc(sizeof(void *) * num_possible_cpus(),
+	stor_device->stor_chns = kcalloc(num_possible_cpus(), sizeof(void *),
 					 GFP_KERNEL);
 	if (stor_device->stor_chns == NULL)
 		return -ENOMEM;

--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -1157,7 +1157,7 @@ static int storvsc_channel_init(struct hv_device *device, bool is_fc)
 	 * We will however populate all the slots to evenly distribute
 	 * the load.
 	 */
-	stor_device->stor_chns = kzalloc(sizeof(void *) * num_possible_cpus(),
+	stor_device->stor_chns = kcalloc(num_possible_cpus(), sizeof(void *),
 					 GFP_KERNEL);
 	if (stor_device->stor_chns == NULL)
 		return -ENOMEM;

--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -1538,8 +1538,6 @@ static void storvsc_on_channel_callback(void *context)
 			break;
 		}
 	} while (1);
-
-	return;
 }
 
 static int storvsc_connect_to_vsp(struct hv_device *device, u32 ring_size,


### PR DESCRIPTION
scsi: storvsc: remove return at end of void function
8d4208c1a73ab30e05da142e0f05b2b02fc26fc9

storvsc_on_channel_callback is a void function and the return
statement at the end is not useful.

Found with checkpatch.

---

scsi: storvsc: Prefer kcalloc over kzalloc with multiply
e04085285b829dc922e78768a9abb390a8caed31

Use kcalloc for allocating an array instead of kzalloc with multiply,
kcalloc is the preferred API.

Found with checkpatch.