### PR TITLE
RH7: Update rhel7-hv-driver-install to include mlx module install

### DIFF
--- a/hv-rhel7.x/hv/rhel7-hv-driver-install
+++ b/hv-rhel7.x/hv/rhel7-hv-driver-install
@@ -9,7 +9,7 @@ make -C /lib/modules/$(uname -r)/build M=`pwd` modules
 [ $? -eq 0 ] || exit 1
 
 echo "Installing Modules"
-cp -f ./*.ko /lib/modules/$(uname -r)/extra/
+cp -f --parents $(find . -name '*.ko') /lib/modules/$(uname -r)/extra/
 [ $? -eq 0 ] || exit 1
 
 echo "Generating Module dependencies"


### PR DESCRIPTION
In 4.2.0 and 4.2.1 branches, the Mellanox module is included in the mlx4 folder, however it is not installed because it is omitted in the copy command. 