### PR TITLE
[rhel7.x] [mlx4] net/mlx4_core: Avoid delays during VF driver device …

### DIFF
--- a/hv-rhel7.x/hv/mlx4/main.c
+++ b/hv-rhel7.x/hv/mlx4/main.c
@@ -78,6 +78,9 @@ MODULE_PARM_DESC(msi_x, "attempt to use MSI-X if nonzero");
 
 #endif /* CONFIG_PCI_MSI */
 
+/* upstream patch: 4cbe4dac82e423ecc9a0ba46af24a860853259f4 */
+#define MLX4_INTERFACE_STATE_NOWAIT 4
+
 static uint8_t num_vfs[3] = {0, 0, 0};
 static int num_vfs_argc;
 module_param_array(num_vfs, byte , &num_vfs_argc, 0444);
@@ -1915,6 +1918,14 @@ static int mlx4_comm_check_offline(struct mlx4_dev *dev)
 			       (u32)(1 << COMM_CHAN_OFFLINE_OFFSET));
 		if (!offline_bit)
 			return 0;
+
+		/* If device removal has been requested,
+		 * do not continue retrying.
+		 */
+		if (dev->persist->interface_state &
+		    MLX4_INTERFACE_STATE_NOWAIT)
+			break;
+
 		/* There are cases as part of AER/Reset flow that PF needs
 		 * around 100 msec to load. We therefore sleep for 100 msec
 		 * to allow other tasks to make use of that CPU during this
@@ -3928,6 +3939,9 @@ static void mlx4_remove_one(struct pci_dev *pdev)
 	struct mlx4_priv *priv = mlx4_priv(dev);
 	struct devlink *devlink = priv_to_devlink(priv);
 	int active_vfs = 0;
+
+	if (mlx4_is_slave(dev))
+		persist->interface_state |= MLX4_INTERFACE_STATE_NOWAIT;
 
 	mutex_lock(&persist->interface_state_mutex);
 	persist->interface_state |= MLX4_INTERFACE_STATE_DELETION;


### PR DESCRIPTION
…shutdown

commit 4cbe4dac82e423ecc9a0ba46af24a860853259f4
Author: Jack Morgenstein <jackm@dev.mellanox.co.il>

Some Hypervisors detach VFs from VMs by instantly causing an FLR event
to be generated for a VF.

In the mlx4 case, this will cause that VF's comm channel to be disabled
before the VM has an opportunity to invoke the VF device's "shutdown"
method.

For such Hypervisors, there is a race condition between the VF's
shutdown method and its internal-error detection/reset thread.

The internal-error detection/reset thread (which runs every 5 seconds)
also
detects a disabled comm channel. If the internal-error detection/reset
flow wins the race, we still get delays (while that flow tries
repeatedly
to detect comm-channel recovery).

The cited commit fixed the command timeout problem when the
internal-error detection/reset flow loses the race.

This commit avoids the unneeded delays when the internal-error
detection/reset flow wins.

Fixes: d585df1c5ccf ("net/mlx4_core: Avoid command timeouts during VF
driver device shutdown")
Signed-off-by: Jack Morgenstein <jackm@dev.mellanox.co.il>
Reported-by: Simon Xiao <sixiao@microsoft.com>