### PR TITLE
[hv-rhel6.x] hv_netvsc: change netvsc device default duplex to FULL

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -836,7 +836,7 @@ static void netvsc_init_settings(struct net_device *dev)
 	struct net_device_context *ndc = netdev_priv(dev);
 
 	ndc->speed = SPEED_UNKNOWN;
-	ndc->duplex = DUPLEX_UNKNOWN;
+	ndc->duplex = DUPLEX_FULL;
 }
 
 static int netvsc_get_settings(struct net_device *dev, struct ethtool_cmd *cmd)


### PR DESCRIPTION
author: Simon Xiao <sixiao@microsoft.com>
commit f3c9d40ee12926f330a1dfebce0bebadd1406ba6

The netvsc device supports full duplex by default.
This warnings in log from bonding device which did not like
seeing UNKNOWN duplex.