### PR TITLE
Tools: hv: vss: Thaw the filesystem and continue if freeze call has timed out

### DIFF
--- a/hv-rhel6.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel6.x/hv/tools/hv_vss_daemon.c
@@ -262,7 +262,9 @@ int main(int argc, char *argv[])
 		if (len != sizeof(struct hv_vss_msg)) {
 			syslog(LOG_ERR, "write failed; error: %d %s", errno,
 			       strerror(errno));
-			exit(EXIT_FAILURE);
+
+			if (op == VSS_OP_FREEZE)
+					vss_operate(VSS_OP_THAW);
 		}
 	}
 

--- a/hv-rhel7.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel7.x/hv/tools/hv_vss_daemon.c
@@ -262,7 +262,9 @@ int main(int argc, char *argv[])
 		if (len != sizeof(struct hv_vss_msg)) {
 			syslog(LOG_ERR, "write failed; error: %d %s", errno,
 			       strerror(errno));
-			exit(EXIT_FAILURE);
+
+			if (op == VSS_OP_FREEZE)
+					vss_operate(VSS_OP_THAW);
 		}
 	}
 


### PR DESCRIPTION
6113e3d28149dee33f10e92df6a16efb2b9cf473

If a FREEZE operation takes too long, the driver may time out and move
on
to another  operation. The daemon is unaware of this and attempts to
notify the driver that the FREEZE succeeded. This results in an error
from
the driver and the daemon leaves the filesystem in frozen state.

Fix this by thawing the filesystem and continuing.