### PR TITLE
RH6/RH7: Avoid deadlock warning from reentering smp_call_function_sin…

### DIFF
--- a/hv-rhel6.x/hv/hyperv_vmbus.h
+++ b/hv-rhel6.x/hv/hyperv_vmbus.h
@@ -448,7 +448,8 @@ static inline void hv_poll_channel(struct vmbus_channel *channel,
 	if (!channel)
 		return;
 	
-	if (in_interrupt() && (channel->target_cpu == smp_processor_id())) {
+	if ((irqs_disabled() || in_interrupt()) &&
+	    (channel->target_cpu == smp_processor_id())) {
                cb(channel);
                return;
 	}

--- a/hv-rhel7.x/hv/hyperv_vmbus.h
+++ b/hv-rhel7.x/hv/hyperv_vmbus.h
@@ -436,10 +436,11 @@ static inline void hv_poll_channel(struct vmbus_channel *channel,
 	if (!channel)
 		return;
 
-	if (in_interrupt() && (channel->target_cpu == smp_processor_id())) {
-               cb(channel);
-               return;
-       }
+	if ((irqs_disabled() || in_interrupt()) &&
+	    (channel->target_cpu == smp_processor_id())) {
+		cb(channel);
+		return;
+	}
 
 	smp_call_function_single(channel->target_cpu, cb, channel, true);
 }


### PR DESCRIPTION
…gle()