### PR TITLE
RHEL5,6,7 VSS - Skip freezing filesystems backed by loop devices.

### DIFF
--- a/hv-rhel5.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel5.x/hv/tools/hv_vss_daemon.c
@@ -76,7 +76,8 @@ static int vss_do_freeze(char *dir, unsigned int cmd)
 
 static int vss_operate(int operation)
 {
-	char match[] = "/dev/";
+	char match_dev[] = "/dev/";
+	char match_loop[] = "/dev/loop";
 	FILE *mounts;
 	struct mntent *ent;
 	char errdir[1024] = {0};
@@ -99,8 +100,10 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match, strlen(match)))
-			continue;
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+                        continue;
+                if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
+                        continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;
 		if (strcmp(ent->mnt_type, "vfat") == 0)

--- a/hv-rhel5.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel5.x/hv/tools/hv_vss_daemon.c
@@ -100,9 +100,9 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)) != 0)
                         continue;
-                if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
+		if (strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)) == 0)
                         continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;

--- a/hv-rhel6.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel6.x/hv/tools/hv_vss_daemon.c
@@ -91,9 +91,9 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)) != 0)
                         continue;
-                if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
+		if (strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)) == 0)
                         continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;

--- a/hv-rhel6.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel6.x/hv/tools/hv_vss_daemon.c
@@ -67,7 +67,8 @@ static int vss_do_freeze(char *dir, unsigned int cmd)
 
 static int vss_operate(int operation)
 {
-	char match[] = "/dev/";
+	char match_dev[] = "/dev/";
+	char match_loop[] = "/dev/loop";
 	FILE *mounts;
 	struct mntent *ent;
 	char errdir[1024] = {0};
@@ -90,8 +91,10 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match, strlen(match)))
-			continue;
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+                        continue;
+                if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
+                        continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;
 		if (strcmp(ent->mnt_type, "vfat") == 0)

--- a/hv-rhel7.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel7.x/hv/tools/hv_vss_daemon.c
@@ -91,9 +91,9 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)) != 0)
 			continue;
-		if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
+		if (strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)) == 0)
 			continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;

--- a/hv-rhel7.x/hv/tools/hv_vss_daemon.c
+++ b/hv-rhel7.x/hv/tools/hv_vss_daemon.c
@@ -67,7 +67,8 @@ static int vss_do_freeze(char *dir, unsigned int cmd)
 
 static int vss_operate(int operation)
 {
-	char match[] = "/dev/";
+	char match_dev[] = "/dev/";
+	char match_loop[] = "/dev/loop";
 	FILE *mounts;
 	struct mntent *ent;
 	char errdir[1024] = {0};
@@ -90,7 +91,9 @@ static int vss_operate(int operation)
 		return -1;
 
 	while ((ent = getmntent(mounts))) {
-		if (strncmp(ent->mnt_fsname, match, strlen(match)))
+		if (strncmp(ent->mnt_fsname, match_dev, strlen(match_dev)))
+			continue;
+		if (!strncmp(ent->mnt_fsname, match_loop, strlen(match_loop)))
 			continue;
 		if (hasmntopt(ent, MNTOPT_RO) != NULL)
 			continue;


### PR DESCRIPTION
The hypervvssd daemon freezes loop devices. This results in deadlocks if the thawing doesn't occur in the reverse order and the loop backed filesystem is thawed before the filesystem that contains the backing file.
This is especially evident in cPanel VMs as cPanel setups loop devices on its own.

This commit skips over loop-backed filesystems. I decided upon this as this is whats VMware says it did with open-vm-tools (https://github.com/vmware/open-vm-tools/issues/6).
If needed I could also supply a patch that stores the freeze order and replays it in reverse for thawing. (That would be a more error-prone commit than this one though.)


**NOTE**: Tested on CentOS7.3 **only** (_should work equally well with other versions though as the changes are minimal_).