### PR TITLE
Add "_0" back into vmbus device name

### DIFF
--- a/hv-rhel5.x/hv/vmbus_drv.c
+++ b/hv-rhel5.x/hv/vmbus_drv.c
@@ -933,7 +933,7 @@ int vmbus_device_register(struct hv_device *child_device_obj)
 {
 	int ret = 0;
 
-	dev_set_name(&child_device_obj->device, "vmbus_%d",
+	dev_set_name(&child_device_obj->device, "vmbus_0_%d",
 		     child_device_obj->channel->id);
 
 	child_device_obj->device.bus = &hv_bus;


### PR DESCRIPTION
VMbus device names had format "vmbus_0_%d" in LIS 3.5, but were changed in LIS 4.0 and later to be "vmbus_%d".  This change broke 'kudzu' in RHEL/CentOS 5.x which has specific code for parsing the "_0".  So changing this back to the original format.  Change is made in the RHEL/CentOS 5.x branch only because 'kudzu' is not used in RHEL/CentOS 6.x and 7.x.