### PR TITLE
netvsc: use typed pointer for internal state

### DIFF
--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -786,8 +786,7 @@ struct netvsc_device {
 	spinlock_t sc_lock; /* Protects num_sc_offered variable */
 	u32 num_sc_offered;
 
-	/* Holds rndis device info */
-	void *extension;
+	struct rndis_device *extension;
 
 	int ring_size;
 

--- a/hv-rhel7.x/hv/hyperv_net.h
+++ b/hv-rhel7.x/hv/hyperv_net.h
@@ -772,7 +772,7 @@ struct netvsc_device {
 	u32 num_sc_offered;
 
 	/* Holds rndis device info */
-	void *extension;
+	struct rndis_device *extension;
 
 	int ring_size;
 

--- a/hv-rhel7.x/hv/hyperv_net.h
+++ b/hv-rhel7.x/hv/hyperv_net.h
@@ -771,7 +771,6 @@ struct netvsc_device {
 	spinlock_t sc_lock; /* Protects num_sc_offered variable */
 	u32 num_sc_offered;
 
-	/* Holds rndis device info */
 	struct rndis_device *extension;
 
 	int ring_size;


### PR DESCRIPTION
2d05b56097664e1d8b7fd690e6eac03cc6a82cc3

The element netvsc_device:extension is always a pointer to RNDIS
information.
