### PR TITLE
[SRIOV] check in the SRIOV config files

### DIFF
--- a/tools/sriov/60-hyperv-sriov.rules
+++ b/tools/sriov/60-hyperv-sriov.rules
@@ -1,0 +1,2 @@
+# Assign Hyper-V VF NICs to stable names, and call bonding config script
+SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", PROGRAM="/usr/sbin/hv_vf_name", NAME:="vf%c", RUN+="/usr/sbin/bondvf_lock"

--- a/tools/sriov/bondvf_lock
+++ b/tools/sriov/bondvf_lock
@@ -1,0 +1,4 @@
+#!/bin/bash
+# A wrapper to call bondvf.sh. The flock prevents execution overlap.
+
+flock -e -w 2 /tmp/bondvf_lock.file /usr/sbin/bondvf.sh

--- a/tools/sriov/hv_vf_name
+++ b/tools/sriov/hv_vf_name
@@ -1,0 +1,5 @@
+#!/bin/bash
+# On HyperV/Azure VMs, we use VF serial number as the PCI domain. This number
+# is used as part of VF nic names for persistency.
+
+echo $DEVPATH | awk -F"/pci" '{print $2}' | cut -d: -f1 | sed 's/^0*//'


### PR DESCRIPTION
60-hyperv-sriov.rules: name the VF device in udev rule;
hv_vf_name: get the VF PCI ID;
bondvf_lock: a wrapper of bondvf.sh with file lock support.