### PR TITLE
RH7: Make sure to release channel lock during rescind.

### DIFF
--- a/hv-rhel7.x/hv/vmbus_drv.c
+++ b/hv-rhel7.x/hv/vmbus_drv.c
@@ -678,7 +678,7 @@ static void vmbus_device_release(struct device *device)
 	mutex_lock(&vmbus_connection.channel_mutex);
 	hv_process_channel_removal(channel,
 				   channel->offermsg.child_relid);
-	mutex_lock(&vmbus_connection.channel_mutex);
+	mutex_unlock(&vmbus_connection.channel_mutex);
 	kfree(hv_dev);
 
 }


### PR DESCRIPTION
This fixes commit 67c89f4c2120d52a39c654d96aff6b57ae707bad.

RH7: Drivers: hv: vmbus: Fix rescind handling