### PR TITLE
Remove 4th dash from device_id and class_id GUIDs

### DIFF
--- a/hv-rhel5.x/hv/vmbus_drv.c
+++ b/hv-rhel5.x/hv/vmbus_drv.c
@@ -209,7 +209,7 @@ static ssize_t vmbus_show_device_attr(struct device *dev,
 
 	if (!strcmp(dev_attr->attr.name, "class_id")) {
 		ret = sprintf(buf, "{%02x%02x%02x%02x-%02x%02x-%02x%02x-"
-				"%02x%02x-%02x%02x%02x%02x%02x%02x}\n",
+				"%02x%02x%02x%02x%02x%02x%02x%02x}\n",
 				device_info->chn_type.b[3],
 				device_info->chn_type.b[2],
 				device_info->chn_type.b[1],
@@ -228,7 +228,7 @@ static ssize_t vmbus_show_device_attr(struct device *dev,
 				device_info->chn_type.b[15]);
 	} else if (!strcmp(dev_attr->attr.name, "device_id")) {
 		ret = sprintf(buf, "{%02x%02x%02x%02x-%02x%02x-%02x%02x-"
-				"%02x%02x-%02x%02x%02x%02x%02x%02x}\n",
+				"%02x%02x%02x%02x%02x%02x%02x%02x}\n",
 				device_info->chn_instance.b[3],
 				device_info->chn_instance.b[2],
 				device_info->chn_instance.b[1],


### PR DESCRIPTION
Remove the 4th dash from device_id and class_id GUIDs so the string format matches the LIS that is built-in RHEL/Cent/OS 5.x releases and matches what kudzu expects.  Kudzu is doing string compares to find the class_id, and the extra dash when LIS is installed causes the compares to fail, which in turn causes the network to not be configured when rebooting after installing LIS.