### PR TITLE
RH6: Avoid scheduling rescind work on global workqueue.

### DIFF
--- a/hv-rhel6.x/hv/vmbus_drv.c
+++ b/hv-rhel6.x/hv/vmbus_drv.c
@@ -608,11 +608,15 @@ void vmbus_on_msg_dpc(unsigned long data)
 		switch (hdr->msgtype) {
 		case CHANNELMSG_RESCIND_CHANNELOFFER:
 			/*
-			 * If we are handling the rescind message;
-			 * schedule the work on the global work queue.
+			 * Workaround for RHEL 6.X kernels:
+			 * Don't schedule rescind work on global queue. 
+			 * For KVP/VSS, this may lead to global
+			 * workqueue attempting to flush itself and a
+			 * deadlock.
 			 */
-			schedule_work_on(vmbus_connection.connect_cpu,
-					 &ctx->work);
+			queue_work_on(vmbus_connection.connect_cpu,
+				      vmbus_connection.work_queue,
+				      &ctx->work);
 			break;
 
 		case CHANNELMSG_OFFERCHANNEL:


### PR DESCRIPTION
This fixes an issue introduced by backport commit:
f3ad7fdb1e2129c23092ca7d2a9a9f1c6cfb6d83