### PR TITLE
Add hotplug support for >Rhel 7.3

### DIFF
--- a/hv-rhel7.x/hv/hv.c
+++ b/hv-rhel7.x/hv/hv.c
@@ -59,6 +59,9 @@ int hv_init(void)
 	 * we do this at module load time.
 	 */
 	hyperv_init();
+
+	memset(hv_context.clk_evt, 0, sizeof(void *) * NR_CPUS);
+
 	hv_print_host_info();
 
 	if (!hv_is_hypercall_page_setup())
@@ -183,13 +186,13 @@ int hv_synic_alloc(void)
 		tasklet_init(&hv_cpu->msg_dpc,
 			     vmbus_on_msg_dpc, (unsigned long) hv_cpu);
 
-		hv_cpu->clk_evt = kzalloc(sizeof(struct clock_event_device),
-					  GFP_KERNEL);
-		if (hv_cpu->clk_evt == NULL) {
+		hv_context.clk_evt[cpu] = kzalloc(sizeof(struct clock_event_device),
+						  GFP_ATOMIC);
+		if (hv_context.clk_evt[cpu] == NULL) {
 			pr_err("Unable to allocate clock event device\n");
 			goto err;
 		}
-		hv_init_clockevent_device(hv_cpu->clk_evt, cpu);
+		hv_init_clockevent_device(hv_context.clk_evt[cpu], cpu);
 
 		hv_cpu->synic_message_page =
 			(void *)get_zeroed_page(GFP_ATOMIC);
@@ -234,6 +237,8 @@ void hv_synic_free(void)
 			free_page((unsigned long)hv_cpu->synic_message_page);
 		if (hv_cpu->post_msg_page)
 			free_page((unsigned long)hv_cpu->post_msg_page);
+		if (hv_context.clk_evt[cpu])
+			kfree(hv_context.clk_evt[cpu]);
 	}
 
 	kfree(hv_context.hv_numa_map);
@@ -298,7 +303,7 @@ int hv_synic_cpu_used(unsigned int cpu)
  * retrieve the initialized message and event pages.  Otherwise, we create and
  * initialize the message and event pages.
  */
-void hv_synic_init(void *arg)
+void hv_synic_init(unsigned int arg)
 {
 	union hv_synic_simp simp;
 	union hv_synic_siefp siefp;
@@ -378,18 +383,14 @@ void hv_synic_clockevents_cleanup(void)
 	if (!(ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE))
 		return;
 
-	for_each_present_cpu(cpu) {
-		struct hv_per_cpu_context *hv_cpu
-			= per_cpu_ptr(hv_context.cpu_context, cpu);
-
-		clockevents_unbind_device(hv_cpu->clk_evt, cpu);
-	}
+	for_each_present_cpu(cpu)
+		clockevents_unbind_device(hv_context.clk_evt[cpu], cpu);
 }
 #endif
 /*
  * hv_synic_cleanup - Cleanup routine for hv_synic_init().
  */
-void hv_synic_cleanup(void *arg)
+void hv_synic_cleanup(unsigned int cpu)
 {
 	union hv_synic_sint shared_sint;
 	union hv_synic_simp simp;
@@ -415,13 +416,10 @@ void hv_synic_cleanup(void *arg)
 	}
 #else
 */
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
-		struct hv_per_cpu_context *hv_cpu
-			= this_cpu_ptr(hv_context.cpu_context);
-
-		hv_ce_setmode(CLOCK_EVT_MODE_SHUTDOWN, hv_cpu->clk_evt);
-		put_cpu_ptr(hv_cpu);
-	}
+	/* Turn off clockevent device */
+	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+		hv_ce_setmode(CLOCK_EVT_MODE_SHUTDOWN,
+			      hv_context.clk_evt[cpu]);
 
 	hv_get_synint_state(HV_X64_MSR_SINT0 + VMBUS_MESSAGE_SINT,
 			    shared_sint.as_uint64);

--- a/hv-rhel7.x/hv/hv.c
+++ b/hv-rhel7.x/hv/hv.c
@@ -239,6 +239,58 @@ void hv_synic_free(void)
 	kfree(hv_context.hv_numa_map);
 }
 
+void hv_clockevents_bind(int cpu)
+{
+	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+		clockevents_config_and_register(hv_context.clk_evt[cpu],
+						HV_TIMER_FREQUENCY,
+						HV_MIN_DELTA_TICKS,
+						HV_MAX_MAX_DELTA_TICKS);
+}
+
+void hv_clockevents_unbind(int cpu)
+{
+	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+		clockevents_unbind_device(hv_context.clk_evt[cpu], cpu);
+}
+
+int hv_synic_cpu_used(unsigned int cpu)
+{
+	struct vmbus_channel *channel, *sc;
+	bool channel_found = false;
+	unsigned long flags;
+
+	/*
+	 * Search for channels which are bound to the CPU we're about to
+	 * cleanup. In case we find one and vmbus is still connected we need to
+	 * fail, this will effectively prevent CPU offlining. There is no way
+	 * we can re-bind channels to different CPUs for now.
+	 */
+	mutex_lock(&vmbus_connection.channel_mutex);
+	list_for_each_entry(channel, &vmbus_connection.chn_list, listentry) {
+		if (channel->target_cpu == cpu) {
+			channel_found = true;
+			break;
+		}
+		spin_lock_irqsave(&channel->lock, flags);
+		list_for_each_entry(sc, &channel->sc_list, sc_list) {
+			if (sc->target_cpu == cpu) {
+				channel_found = true;
+				break;
+			}
+		}
+		spin_unlock_irqrestore(&channel->lock, flags);
+		if (channel_found)
+			break;
+	}
+	mutex_unlock(&vmbus_connection.channel_mutex);
+
+	if (channel_found && vmbus_connection.conn_state == CONNECTED)
+		return 1;
+
+	return 0;
+}
+
 /*
  * hv_synic_init - Initialize the Synthethic Interrupt Controller.
  *
@@ -307,16 +359,11 @@ void hv_synic_init(void *arg)
 	hv_get_vp_index(vp_index);
 	hv_context.vp_index[cpu] = (u32)vp_index;
 
-#ifdef NOTYET
 	/*
 	 * Register the per-cpu clockevent source.
 	 */
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
-		clockevents_config_and_register(hv_cpu->clk_evt,
-						HV_TIMER_FREQUENCY,
-						HV_MIN_DELTA_TICKS,
-						HV_MAX_MAX_DELTA_TICKS);
-#endif
+	hv_clockevents_bind(cpu);
+
 	return;
 }
 

--- a/hv-rhel7.x/hv/hyperv_vmbus.h
+++ b/hv-rhel7.x/hv/hyperv_vmbus.h
@@ -216,7 +216,6 @@ struct hv_per_cpu_context {
 	 * per-cpu list of the channels based on their CPU affinity.
 	 */
 	struct list_head chan_list;
-	struct clock_event_device *clk_evt;
 };
 
 struct hv_context {
@@ -242,6 +241,8 @@ struct hv_context {
 	 */
 	u32 vp_index[NR_CPUS];
 
+	struct clock_event_device *clk_evt[NR_CPUS];
+
 	/*
          * To manage allocations in a NUMA node.
          * Array indexed by numa node ID.
@@ -263,11 +264,17 @@ extern int hv_synic_alloc(void);
 
 extern void hv_synic_free(void);
 
-extern void hv_synic_init(void *irqarg);
+extern void hv_synic_init(unsigned int cpu);
 
-extern void hv_synic_cleanup(void *arg);
+extern void hv_synic_cleanup(unsigned int cpu);
 
 extern void hv_synic_clockevents_cleanup(void);
+
+extern void hv_clockevents_bind(int cpu);
+
+extern void hv_clockevents_unbind(int cpu);
+
+extern int hv_synic_cpu_used(unsigned int cpu);
 
 /* Interface */
 


### PR DESCRIPTION
1) Use notifier_block to monitor CPU hotplug events;
2) Fail the hot-unplug if this CPU is used by VMBUS channel;
3) Refine existing interface to make them fit new structures for hv_synic_* functions.

This patch referenced kernel linux-3.10.0 (693).