### PR TITLE
Fix build break on RHEL 7.2

### DIFF
--- a/hv-rhel7.x/hv/channel_mgmt.c
+++ b/hv-rhel7.x/hv/channel_mgmt.c
@@ -600,8 +600,11 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 	int next_node;
 	struct cpumask available_mask;
 	struct cpumask *alloced_mask;
+
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 	struct cpumask *cpu_sibling_mask;
 	struct cpumask *cpu_thread_tmp_mask;
+#endif
 
 	if ((vmbus_proto_version == VERSION_WS2008) ||
 	    (vmbus_proto_version == VERSION_WIN7) || (!perf_chn)) {
@@ -666,6 +669,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 			cpumask_clear(&primary->alloced_cpus_in_node);
 	}
 
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 	cpu_thread_tmp_mask = kzalloc(cpumask_size(), GFP_KERNEL);
 	if (!cpu_thread_tmp_mask) {
 		channel->numa_node = 0;
@@ -673,6 +677,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 		channel->target_vp = hv_context.vp_index[0];
 		return;
 	}
+#endif
 
 	while (true) {
 		cur_cpu = cpumask_next(cur_cpu, &available_mask);
@@ -683,6 +688,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 			continue;
 		}
 
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))  
 		cpu_sibling_mask = topology_sibling_cpumask(cur_cpu);
 		cpumask_and(cpu_thread_tmp_mask,
 			    cpu_sibling_mask,
@@ -699,6 +705,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 			cpumask_set_cpu(cur_cpu, alloced_mask);
 			continue;
 		}
+#endif
 
 		if (primary->affinity_policy == HV_LOCALIZED) {
 			/*
@@ -725,7 +732,10 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 
 	channel->target_cpu = cur_cpu;
 	channel->target_vp = hv_context.vp_index[cur_cpu];
+
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 	kfree(cpu_thread_tmp_mask);
+#endif
 }
 
 static void vmbus_wait_for_unload(void)

--- a/hv-rhel7.x/hv/hyperv_vmbus.h
+++ b/hv-rhel7.x/hv/hyperv_vmbus.h
@@ -264,9 +264,15 @@ extern int hv_synic_alloc(void);
 
 extern void hv_synic_free(void);
 
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
 extern void hv_synic_init(unsigned int cpu);
 
 extern void hv_synic_cleanup(unsigned int cpu);
+#else
+extern void hv_synic_init(void *cpu);
+
+extern void hv_synic_cleanup(void *cpu);
+#endif
 
 extern void hv_synic_clockevents_cleanup(void);
 

--- a/hv-rhel7.x/hv/vmbus_drv.c
+++ b/hv-rhel7.x/hv/vmbus_drv.c
@@ -983,7 +983,6 @@ static struct notifier_block hv_cpuhp_notifier __refdata = {
 	.notifier_call = hv_cpuhp_callback,
 	.priority = INT_MAX,
 };
-
 #else
 #ifdef CONFIG_HOTPLUG_CPU
 static int hyperv_cpu_disable(void)
@@ -1019,7 +1018,6 @@ static void hv_cpu_hotplug_quirk(bool vmbus_loaded)
 #endif
 #endif
 
-
 #if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,2))
 /*
  * vmbus interrupt flow handler:
@@ -1049,7 +1047,11 @@ static int vmbus_bus_init(void)
 static int vmbus_bus_init(int irq)
 #endif
 {
-	int ret, cpu;
+	int ret;
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))
+	int cpu;
+#endif
+
 
 	/* Hypervisor initialization...setup hypercall page..etc */
 	ret = hv_init();
@@ -1721,7 +1723,7 @@ static void __exit vmbus_exit(void)
 	cpu_notifier_register_done();
 #else
 	for_each_online_cpu(cpu)
-		smp_call_function_single(cpu, hv_synic_cleanup_oncpu, NULL, 1);
+		smp_call_function_single(cpu, hv_synic_cleanup, NULL, 1);
 	hv_cpu_hotplug_quirk(false);
 #endif
 	hv_synic_free();


### PR DESCRIPTION
The recently added code to support cpu hot-plug does not work on RHEL 7.2 and previous versions.
Add #if to those lines of code, to make it works only on RHEL7.3 and later versions.