### PR TITLE
decui/4.2.4-1121-1340

### DIFF
--- a/hv-rhel7.x/hv/Makefile
+++ b/hv-rhel7.x/hv/Makefile
@@ -70,7 +70,9 @@ CFLAGS_hv_trace.o = -I$(src)
 
 hv_vmbus-y := vmbus_drv.o \
 		 hv.o connection.o channel.o  hv_trace.o \
-		 channel_mgmt.o ring_buffer.o arch/$(ARCH)/hyperv/hv_init.o
+		 channel_mgmt.o ring_buffer.o \
+		 arch/$(ARCH)/hyperv/hv_init.o \
+		 arch/$(ARCH)/hyperv/ms_hyperv_ext.o
 hv_utils-y := hv_util.o hv_kvp.o hv_snapshot.o hv_fcopy.o hv_utils_transport.o
 
 hv_storvsc-y := storvsc_drv.o

--- a/hv-rhel7.x/hv/arch/x86/hyperv/hv_init.c
+++ b/hv-rhel7.x/hv/arch/x86/hyperv/hv_init.c
@@ -170,7 +170,7 @@ void hyperv_init(void)
 	 * Register Hyper-V specific clocksource.
 	 */
 #ifdef CONFIG_X86_64
-	if (ms_hyperv.features & HV_X64_MSR_REFERENCE_TSC_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_X64_MSR_REFERENCE_TSC_AVAILABLE) {
 		union hv_x64_msr_hypercall_contents tsc_msr;
 
 		tsc_pg = __vmalloc(PAGE_SIZE, GFP_KERNEL, PAGE_KERNEL);
@@ -196,7 +196,7 @@ void hyperv_init(void)
 
 register_msr_cs:
 	hyperv_cs = &hyperv_cs_msr;
-	if (ms_hyperv.features & HV_X64_MSR_TIME_REF_COUNT_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_TIME_REF_COUNT_AVAILABLE)
 		clocksource_register_hz(&hyperv_cs_msr, NSEC_PER_SEC/100);
 
 	return;

--- a/hv-rhel7.x/hv/arch/x86/hyperv/ms_hyperv_ext.c
+++ b/hv-rhel7.x/hv/arch/x86/hyperv/ms_hyperv_ext.c
@@ -1,0 +1,38 @@
+/*
+ *
+ * Copyright (C) 2017, Microsoft, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, GOOD TITLE or
+ * NON INFRINGEMENT.  See the GNU General Public License for more
+ * details.
+ *
+ */
+
+#include <linux/types.h>
+#include <lis/asm/hyperv.h>
+#include <lis/asm/mshyperv.h>
+
+/* See the comment near the struct definition to know why we need this */
+struct ms_hyperv_info_external ms_hyperv_ext;
+
+
+/* Copied from the upstream's ms_hyperv_init_platform() */
+void init_ms_hyperv_ext(void)
+{
+	/*
+	 * Extract the features and hints
+	 */
+
+	ms_hyperv_ext.features = cpuid_eax(HYPERV_CPUID_FEATURES);
+	ms_hyperv_ext.misc_features = cpuid_edx(HYPERV_CPUID_FEATURES);
+	ms_hyperv_ext.hints = cpuid_eax(HYPERV_CPUID_ENLIGHTMENT_INFO);
+
+	pr_info("Hyper-V: detected features 0x%x, hints 0x%x\n",
+		ms_hyperv_ext.features, ms_hyperv_ext.hints);
+}

--- a/hv-rhel7.x/hv/arch/x86/include/lis/asm/mshyperv.h
+++ b/hv-rhel7.x/hv/arch/x86/include/lis/asm/mshyperv.h
@@ -28,13 +28,24 @@ enum hv_cpuid_function {
 	HVCPUID_IMPLEMENTATION_LIMITS		= 0x40000005,
 };
 
-struct ms_hyperv_info {
+/*
+ * RHEL 7.x kernels (e.g. 7.0) have different formats of struct ms_hyperv_info,
+ * so we shouldn't use the in-kenrel formats.
+ *
+ * Let's define a new struct ms_hyperv_info_external and use it in the non-builtin
+ * LIS drivers.
+ *
+ * The new struct is initialized in hv-rhel*.x/hv/arch/x86/hyperv/ms_hyperv_ext.c:
+ * void init_ms_hyperv_ext(void)
+ */
+struct ms_hyperv_info_external {
 	u32 features;
 	u32 misc_features;
 	u32 hints;
 };
 
-extern struct ms_hyperv_info ms_hyperv;
+extern struct ms_hyperv_info_external ms_hyperv_ext;
+extern void init_ms_hyperv_ext(void);
 
 /*
  *  * Declare the MSR used to setup pages used to communicate with the hypervisor.

--- a/hv-rhel7.x/hv/hv.c
+++ b/hv-rhel7.x/hv/hv.c
@@ -247,7 +247,7 @@ void hv_synic_free(void)
 #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3))  
 void hv_clockevents_bind(int cpu)
 {
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
 		clockevents_config_and_register(hv_context.clk_evt[cpu],
 						HV_TIMER_FREQUENCY,
 						HV_MIN_DELTA_TICKS,
@@ -256,7 +256,7 @@ void hv_clockevents_bind(int cpu)
 
 void hv_clockevents_unbind(int cpu)
 {
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
 		clockevents_unbind_device(hv_context.clk_evt[cpu], cpu);
 }
 
@@ -345,7 +345,7 @@ void hv_synic_init(void *arg)
 	shared_sint.vector = HYPERVISOR_CALLBACK_VECTOR;
 	shared_sint.masked = false;
 
-	if (ms_hyperv.hints & HV_X64_DEPRECATING_AEOI_RECOMMENDED)
+	if (ms_hyperv_ext.hints & HV_X64_DEPRECATING_AEOI_RECOMMENDED)
 		shared_sint.auto_eoi = false;
 	else
 		shared_sint.auto_eoi = true;
@@ -367,7 +367,7 @@ void hv_synic_init(void *arg)
 	/*
 	 * Register the per-cpu clockevent source.
 	 */
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE) 
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE) 
 		clockevents_config_and_register(hv_cpu->clk_evt, 
 			HV_TIMER_FREQUENCY, 
 			HV_MIN_DELTA_TICKS, 
@@ -388,7 +388,7 @@ void hv_synic_clockevents_cleanup(void)
 {
 	int cpu;
 
-	if (!(ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE))
+	if (!(ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE))
 		return;
 
 	for_each_present_cpu(cpu)
@@ -419,7 +419,7 @@ void hv_synic_cleanup(void *arg)
 	Code locks on 7.3 with no reboot during kdump
 
 	#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7,2))
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
 		struct hv_per_cpu_context *hv_cpu
 			= this_cpu_ptr(hv_context.cpu_context);
 
@@ -430,7 +430,7 @@ void hv_synic_cleanup(void *arg)
 #else
 */
 	/* Turn off clockevent device */
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
 		hv_ce_setmode(CLOCK_EVT_MODE_SHUTDOWN,
 			      hv_context.clk_evt[cpu]);
 

--- a/hv-rhel7.x/hv/vmbus_drv.c
+++ b/hv-rhel7.x/hv/vmbus_drv.c
@@ -1116,9 +1116,9 @@ static int vmbus_bus_init(int irq)
          * Only register if the crash MSRs are available
          */
 #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,2)) 
-	if (ms_hyperv.misc_features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
+	if (ms_hyperv_ext.misc_features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
 #else
-	if (ms_hyperv.features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
 #endif
 		register_die_notifier(&hyperv_die_block);
                 atomic_notifier_chain_register(&panic_notifier_list,
@@ -1795,6 +1795,8 @@ static int __init hv_acpi_init(void)
 	if (x86_hyper != &x86_hyper_ms_hyperv)
 		return -ENODEV;
 
+	init_ms_hyperv_ext();
+
 	init_completion(&probe_event);
 
 	/*
@@ -1857,9 +1859,9 @@ static void __exit vmbus_exit(void)
 	}
 	vmbus_free_channels();
 #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,2))
-        if (ms_hyperv.misc_features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
+        if (ms_hyperv_ext.misc_features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
 #else
-        if (ms_hyperv.features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
+        if (ms_hyperv_ext.features & HV_FEATURE_GUEST_CRASH_MSR_AVAILABLE) {
 #endif
 		unregister_die_notifier(&hyperv_die_block);
 		atomic_notifier_chain_unregister(&panic_notifier_list,


### PR DESCRIPTION
In RHEL 7.0 kernel src code: "arch/x86/include/asm/mshyperv.h":
struct ms_hyperv_info {
        u32 features;
        u32 hints;
};

But in lis-next, we have:
"arch/x86/include/asm/mshyperv.h":
struct ms_hyperv_info {
        u32 features;
        u32 misc_features;
        u32 hints;
};

The boot-up issue is triggered by the below code:

if (ms_hyperv.hints & HV_X64_DEPRECATING_AEOI_RECOMMENDED)
	shared_sint.auto_eoi = false;
else
        shared_sint.auto_eoi = true;

Here hints should be 0xc2c on Win10, and bit 9
(HV_X64_DEPRECATING_AEOI_RECOMMENDED) is 0, so we should set
auto_eoi to true.
But due to the struct mismatch, we could set the field to false,
and the hypervisor won’t be able to deliver any further interrupt
to Linux VM.

The upstream mainline code has added more fields into the struct,
so I think we'd better maintain our own "external" version of the
struct.

Signed-off-by: Dexuan Cui <decui@microsoft.com>