### PR TITLE
hv: kvp: Avoid reading past allocated blocks from KVP file

### DIFF
--- a/hv-rhel6.x/hv/tools/hv_kvp_daemon.c
+++ b/hv-rhel6.x/hv/tools/hv_kvp_daemon.c
@@ -201,6 +201,7 @@ static void kvp_update_mem_state(int pool)
 			syslog(LOG_ERR,
 				"Failed to read file, pool: %d; error: %d %s",
 				 pool, errno, strerror(errno));
+				 kvp_release_lock(pool);
 			exit(EXIT_FAILURE);
 		}
 
@@ -213,6 +214,7 @@ static void kvp_update_mem_state(int pool)
 
 			if (record == NULL) {
 				syslog(LOG_ERR, "malloc failed");
+				kvp_release_lock(pool);
 				exit(EXIT_FAILURE);
 			}
 			continue;
@@ -254,6 +256,8 @@ static int kvp_file_init(void)
 		kvp_file_info[i].fd = fd;
 		kvp_file_info[i].num_blocks = 1;
 		kvp_file_info[i].records = malloc(alloc_unit);
+		if (kvp_file_info[i].records == NULL)
+			return 1;
 		kvp_file_info[i].num_records = 0;
 		kvp_update_mem_state(i);
 	}

--- a/hv-rhel7.x/hv/tools/hv_kvp_daemon.c
+++ b/hv-rhel7.x/hv/tools/hv_kvp_daemon.c
@@ -201,6 +201,7 @@ static void kvp_update_mem_state(int pool)
 			syslog(LOG_ERR,
 				"Failed to read file, pool: %d; error: %d %s",
 				 pool, errno, strerror(errno));
+				 kvp_release_lock(pool);
 			exit(EXIT_FAILURE);
 		}
 
@@ -213,6 +214,7 @@ static void kvp_update_mem_state(int pool)
 
 			if (record == NULL) {
 				syslog(LOG_ERR, "malloc failed");
+				kvp_release_lock(pool);
 				exit(EXIT_FAILURE);
 			}
 			continue;
@@ -254,6 +256,8 @@ static int kvp_file_init(void)
 		kvp_file_info[i].fd = fd;
 		kvp_file_info[i].num_blocks = 1;
 		kvp_file_info[i].records = malloc(alloc_unit);
+		if (kvp_file_info[i].records == NULL)
+			return 1;
 		kvp_file_info[i].num_records = 0;
 		kvp_update_mem_state(i);
 	}


### PR DESCRIPTION
297d6b6e56c2977fc504c61bbeeaa21296923f89

Sync original code changes with upstream commit