### PR TITLE
RH6:Hv netvsc replace divide with mask when computing padding

### DIFF
--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -719,8 +719,7 @@ static u32 netvsc_copy_to_send_buf(struct netvsc_device *net_device,
 
 	/* Add padding */
 	remain = packet->total_data_buflen & (net_device->pkt_align - 1);
-	if (skb && packet->xmit_more && remain &&
-	    packet->cp_partial) {
+	if (skb && packet->xmit_more && remain && !packet->cp_partial) {
 		padding = net_device->pkt_align - remain;
 		rndis_msg->msg_len += padding;
 		packet->total_data_buflen += padding;

--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -715,12 +715,12 @@ static u32 netvsc_copy_to_send_buf(struct netvsc_device *net_device,
 	u32 padding = 0;
 	u32 page_count = packet->cp_partial ? packet->rmsg_pgcnt :
 		packet->page_buf_cnt;
-    u32 remain;
+	u32 remain;
 
 	/* Add padding */
 	remain = packet->total_data_buflen & (net_device->pkt_align - 1);
 	if (skb && packet->xmit_more && remain &&
-	    !packet->cp_partial) {
+		!packet->cp_partial) {
 		padding = net_device->pkt_align - remain;
 		rndis_msg->msg_len += padding;
 		packet->total_data_buflen += padding;

--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -720,7 +720,7 @@ static u32 netvsc_copy_to_send_buf(struct netvsc_device *net_device,
 	/* Add padding */
 	remain = packet->total_data_buflen & (net_device->pkt_align - 1);
 	if (skb && packet->xmit_more && remain &&
-		!packet->cp_partial) {
+	    packet->cp_partial) {
 		padding = net_device->pkt_align - remain;
 		rndis_msg->msg_len += padding;
 		packet->total_data_buflen += padding;

--- a/hv-rhel6.x/hv/netvsc.c
+++ b/hv-rhel6.x/hv/netvsc.c
@@ -713,11 +713,12 @@ static u32 netvsc_copy_to_send_buf(struct netvsc_device *net_device,
 	int i;
 	u32 msg_size = 0;
 	u32 padding = 0;
-	u32 remain = packet->total_data_buflen % net_device->pkt_align;
 	u32 page_count = packet->cp_partial ? packet->rmsg_pgcnt :
 		packet->page_buf_cnt;
+    u32 remain;
 
 	/* Add padding */
+	remain = packet->total_data_buflen & (net_device->pkt_align - 1);
 	if (skb && packet->xmit_more && remain &&
 	    !packet->cp_partial) {
 		padding = net_device->pkt_align - remain;


### PR DESCRIPTION
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=b85e06f7bb1a25dd2e7755d55a2ca313d24ae7ad

Updated for hv-rhel6
hv-rhel7 already updated