### PR TITLE
Update storvsc algorithm for selecting channel for new I/O request

### DIFF
--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -1668,7 +1668,7 @@ static int storvsc_do_io(struct hv_device *device,
 			 */
 			cpumask_and(&alloced_mask, &stor_device->alloced_cpus,
 				    cpumask_of_node(cpu_to_node(q_num)));
-			for_each_cpu(tgt_cpu, &alloced_mask) {
+			for_each_cpu_wrap(tgt_cpu, &alloced_mask, outgoing_channel->target_cpu + 1) {
 				if (tgt_cpu != outgoing_channel->target_cpu) {
 					outgoing_channel =
 					stor_device->stor_chns[tgt_cpu];
@@ -2138,7 +2138,7 @@ static struct scsi_host_template scsi_driver = {
 	.slave_alloc =		storvsc_device_alloc,
 	.slave_destroy =	storvsc_device_destroy,
 	.slave_configure =	storvsc_device_configure,
-	.cmd_per_lun =		255,
+	.cmd_per_lun =		2048,
 	.this_id =		-1,
 	.sg_tablesize = STORVSC_TABLE_SEZE,
 	.use_clustering =	ENABLE_CLUSTERING,


### PR DESCRIPTION
Update the algorithm in storvsc_do_io to look for a channel
starting with the current CPU + 1 and wrap around, rather
than always starting CPU #0 (within the current NUMA node
in both cases). This update spreads VMbus interrupts evenly
across CPUs instead of mostly to CPU #0.

Also update the cmd_per_lun value from 255 to 2048.  Hyper-V
can handle the larger number, and it avoids excessive CPU usage
due to blk and SCSI level requeuing when the number of
outstanding I/O's is larger then 255.