### PR TITLE
Improve hv_fcopy_daemon unit file

### DIFF
--- a/hv-rhel7.x/hv/tools/systemd/hv_fcopy_daemon.service
+++ b/hv-rhel7.x/hv/tools/systemd/hv_fcopy_daemon.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Hyper-V FCOPY daemon
 BindsTo=sys-devices-virtual-misc-vmbus\x21hv_fcopy.device
+ConditionPathExists=/dev/vmbus/hv_fcopy
 
 [Service]
 ExecStart=/usr/sbin/hv_fcopy_daemon -n


### PR DESCRIPTION
When guest services aren't enabled, systemd cannot launch the fcopy service and systemctl status shows a degraded system state.
This patch allows the hv_fcopy_daemon not to make systemctl state degraded anymore.