### PR TITLE
For master branch: Fix VM boot-time hang issues for RHEL 6.x and 7.x on a RS4 host

### DIFF
--- a/hv-rhel6.x/hv/Makefile
+++ b/hv-rhel6.x/hv/Makefile
@@ -54,7 +54,10 @@ CFLAGS_hv_trace.o = -I$(src)
 
 hv_vmbus-y	:= vmbus_drv.o \
 		 hv.o connection.o channel.o hv_trace.o \
-		 channel_mgmt.o ring_buffer.o arch/$(SRCARCH)/hyperv/hv_init.o
+		 channel_mgmt.o ring_buffer.o \
+		 arch/$(SRCARCH)/hyperv/hv_init.o \
+		 arch/$(SRCARCH)/hyperv/ms_hyperv_ext.o
+
 hv_utils-y	:= hv_util.o hv_kvp.o hv_snapshot.o hv_fcopy.o hv_utils_transport.o
 hv_storvsc-y := storvsc_drv.o
 hv_uio_generic-y := uio_hv_generic.o

--- a/hv-rhel6.x/hv/arch/x86/hyperv/hv_init.c
+++ b/hv-rhel6.x/hv/arch/x86/hyperv/hv_init.c
@@ -160,7 +160,7 @@ void hyperv_init(void)
 	 * Register Hyper-V specific clocksource.
 	 */
 #ifdef CONFIG_X86_64
-	if (ms_hyperv.features & HV_X64_MSR_REFERENCE_TSC_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_X64_MSR_REFERENCE_TSC_AVAILABLE) {
 		union hv_x64_msr_hypercall_contents tsc_msr;
 
 		tsc_pg = __vmalloc(PAGE_SIZE, GFP_KERNEL, PAGE_KERNEL);
@@ -190,7 +190,7 @@ void hyperv_init(void)
 
 register_msr_cs:
 	hyperv_cs = &hyperv_cs_msr;
-	if (ms_hyperv.features & HV_X64_MSR_TIME_REF_COUNT_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_TIME_REF_COUNT_AVAILABLE)
 #if  (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,3))
 		clocksource_register(&hyperv_cs_msr);
 #else

--- a/hv-rhel6.x/hv/arch/x86/hyperv/ms_hyperv_ext.c
+++ b/hv-rhel6.x/hv/arch/x86/hyperv/ms_hyperv_ext.c
@@ -1,0 +1,38 @@
+/*
+ *
+ * Copyright (C) 2018, Microsoft, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, GOOD TITLE or
+ * NON INFRINGEMENT.  See the GNU General Public License for more
+ * details.
+ *
+ */
+
+#include <linux/types.h>
+#include <lis/asm/hyperv.h>
+#include <lis/asm/mshyperv.h>
+
+/* See the comment near the struct definition to know why we need this */
+struct ms_hyperv_info_external ms_hyperv_ext;
+
+
+/* Copied from the upstream's ms_hyperv_init_platform() */
+void init_ms_hyperv_ext(void)
+{
+	/*
+	 * Extract the features and hints
+	 */
+
+	ms_hyperv_ext.features = cpuid_eax(HYPERV_CPUID_FEATURES);
+	ms_hyperv_ext.misc_features = cpuid_edx(HYPERV_CPUID_FEATURES);
+	ms_hyperv_ext.hints = cpuid_eax(HYPERV_CPUID_ENLIGHTMENT_INFO);
+
+	pr_info("Hyper-V: detected features 0x%x, hints 0x%x\n",
+		ms_hyperv_ext.features, ms_hyperv_ext.hints);
+}

--- a/hv-rhel6.x/hv/arch/x86/include/lis/asm/mshyperv.h
+++ b/hv-rhel6.x/hv/arch/x86/include/lis/asm/mshyperv.h
@@ -26,13 +26,24 @@ enum hv_cpuid_function {
 	HVCPUID_IMPLEMENTATION_LIMITS		= 0x40000005,
 };
 
-struct ms_hyperv_info {
+/*
+ * Old RHEL 6.x kernels (e.g. 6.7) have different formats of struct
+ * ms_hyperv_info, so we shouldn't use the in-kenrel formats.
+ *
+ * Let's define a new struct ms_hyperv_info_external and use it in the non-builtin
+ * LIS drivers.
+ *
+ * The new struct is initialized in hv-rhel*.x/hv/arch/x86/hyperv/ms_hyperv_ext.c:
+ * void init_ms_hyperv_ext(void)
+ */
+struct ms_hyperv_info_external {
 	u32 features;
 	u32 misc_features;
 	u32 hints;
 };
 
-extern struct ms_hyperv_info ms_hyperv;
+extern struct ms_hyperv_info_external ms_hyperv_ext;
+extern void init_ms_hyperv_ext(void);
 
 /*
  *  * Declare the MSR used to setup pages used to communicate with the hypervisor.

--- a/hv-rhel6.x/hv/hv.c
+++ b/hv-rhel6.x/hv/hv.c
@@ -300,10 +300,21 @@ void hv_synic_init(void *arg)
 	shared_sint.vector = HYPERVISOR_CALLBACK_VECTOR;
 	shared_sint.masked = false;
 
-	if (ms_hyperv.hints & HV_X64_DEPRECATING_AEOI_RECOMMENDED)
+#if (RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(6,9))
+	/*
+	 * RHEL 6.9 and older's hyperv_vector_handler() doesn't have the
+	 * patch: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a33fd4c27b3ad11c66bdadc5fe6075297ca87a6d,
+	 * so we must set shared_sint.auto_eoi to true, otherwise the VM
+	 * hangs when booting up.
+	 */
+	shared_sint.auto_eoi = true;
+#else
+#error  check the src code of RHEL kernel: arch/x86/kernel/cpu/mshyperv.c:hyperv_vector_handler()!!!
+	if (ms_hyperv_ext.hints & HV_X64_DEPRECATING_AEOI_RECOMMENDED)
 		shared_sint.auto_eoi = false;
 	else
-		shared_sint.auto_eoi = true;	
+		shared_sint.auto_eoi = true;
+#endif
 
 	hv_set_synint_state(HV_X64_MSR_SINT0 + VMBUS_MESSAGE_SINT,
 			    shared_sint.as_uint64);
@@ -329,7 +340,7 @@ void hv_synic_init(void *arg)
 	 * Register the per-cpu clockevent source.
 	 */
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 18)
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE)
 		clockevents_register_device(hv_cpu->clk_evt);
 #endif
 #endif
@@ -345,7 +356,7 @@ void hv_synic_clockevents_cleanup(void)
 {
 	int cpu;
 
-	if (!(ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE))
+	if (!(ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE))
 		return;
 
 	for_each_present_cpu(cpu) {
@@ -372,7 +383,7 @@ void hv_synic_cleanup(void *arg)
 
 	/* Turn off clockevent device */
 #if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
 		struct hv_per_cpu_context *hv_cpu
 			= this_cpu_ptr(hv_context.cpu_context);
 
@@ -381,7 +392,7 @@ void hv_synic_cleanup(void *arg)
 		put_cpu_ptr(hv_cpu);
 	}
 #else
-	if (ms_hyperv.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
+	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
 		struct hv_per_cpu_context *hv_cpu
 			= this_cpu_ptr(hv_context.cpu_context);
 


### PR DESCRIPTION
This PR fixes a VM boot-time hang issue on some RS4 hosts, where ms_hyperv_ext.hints.bit9(HV_X64_DEPRECATING_AEOI_RECOMMENDED) = 1.
