### PR TITLE
 netvsc_compat fix for rhel <7.3

### DIFF
--- a/hv-rhel7.x/hv/netvsc_compat.h
+++ b/hv-rhel7.x/hv/netvsc_compat.h
@@ -4,7 +4,11 @@
 
 static inline bool compat_napi_complete_done(struct napi_struct *n, int work_done)
 {
+#if (RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7,3))
+	napi_complete(n);
+#else
 	napi_complete_done(n, work_done);
+#endif
 	return true;
 }
 	

--- a/hv-rhel7.x/hv/netvsc_compat.h
+++ b/hv-rhel7.x/hv/netvsc_compat.h
@@ -14,7 +14,7 @@ static inline bool compat_napi_complete_done(struct napi_struct *n, int work_don
 	
 #define napi_complete_done  compat_napi_complete_done
 
-#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,3))
+#if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,2))
 static inline void __napi_schedule_irqoff(struct napi_struct *n)
 {
 	napi_schedule(n);


### PR DESCRIPTION
lis-next fails to build on 7.3 and older 7.x, fixing 2 different issues.