### PR TITLE
RH7: fix compat layer of __napi_schedule_irqoff()

### DIFF
--- a/hv-rhel7.x/hv/netvsc_compat.h
+++ b/hv-rhel7.x/hv/netvsc_compat.h
@@ -17,7 +17,7 @@ static inline bool compat_napi_complete_done(struct napi_struct *n, int work_don
 #if (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,2))
 static inline void __napi_schedule_irqoff(struct napi_struct *n)
 {
-	napi_schedule(n);
+	__napi_schedule(n);
 }
 #endif
 


### PR DESCRIPTION
fix: a10d539cd1a0421f596d590e18bfc2b9fbdca1c1
	netvsc: introduce compat.h to workaround kernel API changes

Signed-off-by: Haiyang Zhang <haiyangz@microsoft.com>