### PR TITLE
can't compile on rhel 6 with kernel 2.6.32-754.2.1.el6.x86_64

### DIFF
--- a/hv-rhel6.x/hv/hv.c
+++ b/hv-rhel6.x/hv/hv.c
@@ -299,7 +299,7 @@ void hv_synic_init(void *arg)
 	shared_sint.vector = HYPERVISOR_CALLBACK_VECTOR;
 	shared_sint.masked = false;
 
-#if (RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(6,10))
 	/*
 	 * RHEL 6.9 and older's hyperv_vector_handler() doesn't have the
 	 * patch: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a33fd4c27b3ad11c66bdadc5fe6075297ca87a6d,
@@ -350,7 +350,7 @@ void hv_synic_init(void *arg)
  * hv_synic_clockevents_cleanup - Cleanup clockevent devices
  */
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 void hv_synic_clockevents_cleanup(void)
 {
 	int cpu;
@@ -381,7 +381,7 @@ void hv_synic_cleanup(void *arg)
 		return;
 
 	/* Turn off clockevent device */
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	if (ms_hyperv_ext.features & HV_X64_MSR_SYNTIMER_AVAILABLE) {
 		struct hv_per_cpu_context *hv_cpu
 			= this_cpu_ptr(hv_context.cpu_context);

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -237,7 +237,7 @@ static inline bool netvsc_set_hash(u32 *hash, struct sk_buff *skb)
 static inline __u32
 skb_get_hash(struct sk_buff *skb)
 {
-#if defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
         return skb->hash;
 #else
 	__u32 hash;

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -1111,7 +1111,7 @@ static void netvsc_poll_controller(struct net_device *dev)
 }
 #endif
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 static u32 netvsc_get_rxfh_key_size(struct net_device *dev)
 {
 	return NETVSC_HASH_KEYLEN;
@@ -1191,7 +1191,7 @@ static const struct ethtool_ops ethtool_ops = {
 	.get_settings	= netvsc_get_settings,
 	.set_settings	= netvsc_set_settings,
 	.get_rxnfc	= netvsc_get_rxnfc,
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	.get_rxfh_key_size = netvsc_get_rxfh_key_size,
 	.get_rxfh_indir_size = netvsc_rss_indir_size,
 	.get_rxfh	= netvsc_get_rxfh,
@@ -1690,7 +1690,7 @@ static struct  hv_driver netvsc_drv = {
 static int netvsc_netdev_event(struct notifier_block *this,
 			       unsigned long event, void *ptr)
 {
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	/* Not in RHEL 6.8 kernel - check again when 6.9 releases - NHM */
 	struct net_device *event_dev = netdev_notifier_info_to_dev(ptr);
 #else

--- a/hv-rhel6.x/hv/storvsc_drv.c
+++ b/hv-rhel6.x/hv/storvsc_drv.c
@@ -2138,7 +2138,7 @@ static struct scsi_host_template scsi_driver = {
 	.use_clustering =	ENABLE_CLUSTERING,
 	/* Make sure we dont get a sg segment crosses a page boundary */
 	.dma_boundary =		PAGE_SIZE-1,
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	.track_queue_depth =	1,
 #endif
 };
@@ -2278,7 +2278,7 @@ static int storvsc_probe(struct hv_device *device,
 	host->sg_tablesize = (stor_device->max_transfer_bytes >> PAGE_SHIFT);
 #endif
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	/*
 	 * Set the number of HW queues we are supporting.
 	 */

--- a/hv-rhel6.x/hv/vmbus_drv.c
+++ b/hv-rhel6.x/hv/vmbus_drv.c
@@ -1351,7 +1351,7 @@ static struct acpi_driver vmbus_acpi_driver = {
 	},
 };
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 static void hv_kexec_handler(void)
 {
 	int cpu;
@@ -1364,7 +1364,7 @@ static void hv_kexec_handler(void)
 };
 #endif
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 static void hv_crash_handler(struct pt_regs *regs)
 {
 	vmbus_initiate_unload();
@@ -1417,7 +1417,7 @@ static int __init hv_acpi_init(void)
 #endif
 	if (ret)
 		goto cleanup;
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	hv_setup_kexec_handler(hv_kexec_handler);
 	hv_setup_crash_handler(hv_crash_handler);
 #endif
@@ -1432,12 +1432,12 @@ cleanup:
 static void __exit vmbus_exit(void)
 {
 	int cpu;
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	hv_remove_kexec_handler();
 	hv_remove_crash_handler();
 #endif
 	vmbus_connection.conn_state = DISCONNECTED;
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,9))
+#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(6,10))
 	hv_synic_clockevents_cleanup();
 #endif
 	vmbus_disconnect();


### PR DESCRIPTION
With kernel version headers returning 6.10, many of the #DEFINES checking for 6.9 still don't work with 6.10. Don't know enough to change the code to work with 6.10, or if they can be changed. So changing the check so it only tries with kernel version 6.11. Without the change, it fails to compile.