### PR TITLE
RH7,RH6:paralleltasks:added -jParallelTasks option of Make modules

### DIFF
--- a/hv-rhel6.x/hv/rhel6-hv-driver-install
+++ b/hv-rhel6.x/hv/rhel6-hv-driver-install
@@ -1,13 +1,15 @@
 echo "Building Modules"
 if [ "$KERNEL_VERSION" == "" ]
 then
-	KERNEL_VERSION = $(uname -r)
+	KERNEL_VERSION=$(uname -r)
 fi
+
+ParallelTasks=`cat /proc/cpuinfo | grep processor | wc -l`
 
 make -C /lib/modules/$KERNEL_VERSION/build M=`pwd` clean
 [ $? -eq 0 ] || exit 1
 
-make -C /lib/modules/$KERNEL_VERSION/build M=`pwd` modules
+make -j$ParallelTasks -C /lib/modules/$KERNEL_VERSION/build M=`pwd` modules
 [ $? -eq 0 ] || exit 1
 
 echo "Installing Modules"

--- a/hv-rhel7.x/hv/rhel7-hv-driver-install
+++ b/hv-rhel7.x/hv/rhel7-hv-driver-install
@@ -1,15 +1,17 @@
 echo "Building Modules"
 if [ "$KERNEL_VERSION" == "" ]
 then
-	KERNEL_VERSION = $(uname -r)
+	KERNEL_VERSION=$(uname -r)
 fi
+
+ParallelTasks=`cat /proc/cpuinfo | grep processor | wc -l`
 
 echo "Cleaning up from any previous builds"
 make -C /lib/modules/$KERNEL_VERSION/build M=`pwd` clean
 [ $? -eq 0 ] || exit 1
 
 echo "Creating LIS modules"
-make -C /lib/modules/$KERNEL_VERSION/build M=`pwd` modules
+make -j$ParallelTasks -C /lib/modules/$KERNEL_VERSION/build M=`pwd` modules
 [ $? -eq 0 ] || exit 1
 
 echo "Installing Modules"


### PR DESCRIPTION
added $ParallelTasks option of Make modules of rh7, and rh6 rhelx_hv_driver_install, and tested them in centos7.5, 7.0, and 6.0,6.7; they were all passed