### PR TITLE
RH7: hv_netvsc: Fix a network regression after ifdown/ifup

### DIFF
--- a/hv-rhel7.x/hv/netvsc_drv.c
+++ b/hv-rhel7.x/hv/netvsc_drv.c
@@ -134,8 +134,10 @@ static int netvsc_open(struct net_device *net)
 	}
 
 	rdev = nvdev->extension;
-	if (!rdev->link_state)
+	if (!rdev->link_state) {
 		netif_carrier_on(net);
+		netif_tx_wake_all_queues(net);
+	}
 
 	if (vf_netdev) {
 		/* Setting synthetic device up transparently sets


### PR DESCRIPTION
Cherry-picked from lis-next/master: 25c11bb2334036816cb94e643013ba314cbed4eb