### PR TITLE
RH7:hv_netvsc:set master device

### DIFF
--- a/hv-rhel7.x/hv/netvsc_drv.c
+++ b/hv-rhel7.x/hv/netvsc_drv.c
@@ -1857,7 +1857,12 @@ static int netvsc_vf_join(struct net_device *vf_netdev,
 		goto rx_handler_failed;
 	}
 
-	ret = netdev_upper_dev_link(vf_netdev, ndev);
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,4))
+        ret = netdev_master_upper_dev_link(vf_netdev, ndev,
+                                           NULL, NULL);
+#else
+        ret = netdev_master_upper_dev_link(vf_netdev, ndev);
+#endif
 	if (ret != 0) {
 		netdev_err(vf_netdev,
 			   "can not set master device %s (err = %d)\n",


### PR DESCRIPTION
Fix the "No IP address via DHCP" issue when AN is enabled.

Cherry-picked from lis-next/master: 97edf12835fa176a9c61278d49e401e272b02ec6