### PR TITLE
Revert "RH6: hv_netvsc: Fix a deadlock by getting rtnl lock earlier i…

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -1621,21 +1621,7 @@ static int netvsc_probe(struct hv_device *dev,
 	dev_info(&dev->device, "real num tx,rx queues:%u, %u\n",
 		 net->real_num_tx_queues, nvdev->num_chn);
 
-	/* We must get rtnl lock before scheduling nvdev->subchan_work,
-	 * otherwise netvsc_subchan_work() can get rtnl lock first and wait
-	 * all subchannels to show up, but that may not happen because
-	 * netvsc_probe() can't get rtnl lock and as a result vmbus_onoffer()
-	 * -> ... -> device_add() -> ... -> __device_attach() can't get
-	 * the device lock, so all the subchannels can't be processed --
-	 * finally netvsc_subchan_work() hangs for ever
-	 */
-	rtnl_lock();
-	if (nvdev->num_chn > 1)
-		schedule_work(&nvdev->subchan_work);
-
-	ret = register_netdevice(net);
-	rtnl_unlock();
-
+	ret = register_netdev(net);
 	if (ret != 0) {
 		pr_err("Unable to register netdev.\n");
 		rndis_filter_device_remove(dev, nvdev);

--- a/hv-rhel6.x/hv/rndis_filter.c
+++ b/hv-rhel6.x/hv/rndis_filter.c
@@ -1327,11 +1327,8 @@ struct netvsc_device *rndis_filter_device_add(struct hv_device *dev,
 		netif_napi_add(net, &net_device->chan_table[i].napi,
 				netvsc_poll, NAPI_POLL_WEIGHT);
 
-#if 0
-	Note: we moved this into netvsc_probe() with rtnl_lock held.
 	if (net_device->num_chn > 1)
 		schedule_work(&net_device->subchan_work);
-#endif
 
 out:
 	/* if unavailable, just proceed with one queue */


### PR DESCRIPTION
…n netvsc_probe()"

This reverts commit 321cffab6cd38fb9c0c0295caec8c6ae707e4f95.

This can break changing MTU.