### PR TITLE
RH6:hv:vmbus:Remove the useless API vmbus_get_outgoing_channel() and …

### DIFF
--- a/hv-rhel6.x/hv/channel_mgmt.c
+++ b/hv-rhel6.x/hv/channel_mgmt.c
@@ -419,7 +419,6 @@ void hv_process_channel_removal(u32 relid)
 		primary_channel = channel->primary_channel;
 		spin_lock_irqsave(&primary_channel->lock, flags);
 		list_del(&channel->sc_list);
-		primary_channel->num_sc--;
 		spin_unlock_irqrestore(&primary_channel->lock, flags);
 	}
 
@@ -450,60 +449,15 @@ void vmbus_free_channels(void)
 }
 
 
-/*
- * vmbus_process_offer - Process the offer by creating a channel/device
- * associated with this offer
- */
-static void vmbus_process_offer(struct vmbus_channel *newchannel)
+/* Note: the function can run concurrently for primary/sub channels. */
+static void vmbus_add_channel_work(struct work_struct *work)
 {
-	struct vmbus_channel *channel;
-	bool fnew = true;
+	struct vmbus_channel *newchannel =
+		container_of(work, struct vmbus_channel, add_channel_work);
+	struct vmbus_channel *primary_channel = newchannel->primary_channel;
 	unsigned long flags;
 	u16 dev_type;
 	int ret;
-
-	/* Make sure this is a new offer */
-	mutex_lock(&vmbus_connection.channel_mutex);
-
-	/*
-	 * Now that we have acquired the channel_mutex,
-	 * we can release the potentially racing rescind thread.
-	 */
-	atomic_dec(&vmbus_connection.offer_in_progress);
-
-	list_for_each_entry(channel, &vmbus_connection.chn_list, listentry) {
-		if (!uuid_le_cmp(channel->offermsg.offer.if_type,
-			newchannel->offermsg.offer.if_type) &&
-			!uuid_le_cmp(channel->offermsg.offer.if_instance,
-				newchannel->offermsg.offer.if_instance)) {
-			fnew = false;
-			break;
-		}
-	}
-
-	if (fnew)
-		list_add_tail(&newchannel->listentry,
-			      &vmbus_connection.chn_list);
-
-	mutex_unlock(&vmbus_connection.channel_mutex);
-
-	if (!fnew) {
-		/*
-		 * Check to see if this is a sub-channel.
-		 */
-		if (newchannel->offermsg.offer.sub_channel_index != 0) {
-			/*
-			 * Process the sub-channel.
-			 */
-			newchannel->primary_channel = channel;
-			spin_lock_irqsave(&channel->lock, flags);
-			list_add_tail(&newchannel->sc_list, &channel->sc_list);
-			channel->num_sc++;
-			spin_unlock_irqrestore(&channel->lock, flags);
-		} else {
-			goto err_free_chan;
-		}
-	}
 
 	dev_type = hv_get_dev_type(newchannel);
 
@@ -519,30 +473,36 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
 		put_cpu();
 
 	}
-	
-	/*
-	 * This state is used to indicate a successful open
-	 * so that when we do close the channel normally, we
-	 * can cleanup properly
-	 */
-	newchannel->state = CHANNEL_OPEN_STATE;
 
-	if (!fnew) {
-		if (channel->sc_creation_callback != NULL)
-			channel->sc_creation_callback(newchannel);
-		newchannel->probe_done = true;
-		return;
-	}
+    /*
+         * This state is used to indicate a successful open
+         * so that when we do close the channel normally, we
+         * can cleanup properly.
+         */
+    newchannel->state = CHANNEL_OPEN_STATE;
 
-	/*
-	 * Start the process of binding this offer to the driver
-	 * We need to set the DeviceObject field before calling
-	 * vmbus_child_dev_add()
-	 */
+    if (primary_channel != NULL) {
+        /* newchannel is a sub-channel. */
+        struct hv_device *dev = primary_channel->device_obj;
+
+        if (vmbus_add_channel_kobj(dev, newchannel))
+            goto err_deq_chan;
+        
+        if (primary_channel->sc_creation_callback != NULL)
+            primary_channel->sc_creation_callback(newchannel);
+
+        newchannel->probe_done = true;
+        return;
+    }
+
+    /*
+         * Start the process of binding the primary channel to the driver
+         */
 	newchannel->device_obj = vmbus_device_create(
 		&newchannel->offermsg.offer.if_type,
 		&newchannel->offermsg.offer.if_instance,
 		newchannel);
+
 	if (!newchannel->device_obj)
 		goto err_deq_chan;
 
@@ -567,13 +527,28 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
 
 err_deq_chan:
 	mutex_lock(&vmbus_connection.channel_mutex);
-	list_del(&newchannel->listentry);
+
+	/*
+	 * We need to set the flag, otherwise
+	 * vmbus_onoffer_rescind() can be blocked.
+	 */
+	newchannel->probe_done = true;
+
+	if (primary_channel == NULL) {
+		list_del(&newchannel->listentry);
+	} else {
+		spin_lock_irqsave(&primary_channel->lock, flags);
+		list_del(&newchannel->sc_list);
+		spin_unlock_irqrestore(&primary_channel->lock, flags);
+	}
+
 	mutex_unlock(&vmbus_connection.channel_mutex);
 
 	if (newchannel->target_cpu != get_cpu()) {
 		put_cpu();
 		smp_call_function_single(newchannel->target_cpu,
-					 percpu_channel_deq, newchannel, true);
+					 percpu_channel_deq,
+					 newchannel, true);
 	} else {
 		percpu_channel_deq(newchannel);
 		put_cpu();
@@ -581,8 +556,91 @@ err_deq_chan:
 
 	vmbus_release_relid(newchannel->offermsg.child_relid);
 
-err_free_chan:
 	free_channel(newchannel);
+}
+
+ /*
+   * vmbus_process_offer - Process the offer by creating a channel/device
+   * associated with this offer
+   */
+static void vmbus_process_offer(struct vmbus_channel *newchannel)
+{
+	struct vmbus_channel *channel;
+	struct workqueue_struct *wq;
+	unsigned long flags;
+	bool fnew = true;
+
+	mutex_lock(&vmbus_connection.channel_mutex);
+
+	/*
+	 * Now that we have acquired the channel_mutex,
+	 * we can release the potentially racing rescind thread.
+ 	 */
+	atomic_dec(&vmbus_connection.offer_in_progress);
+
+	list_for_each_entry(channel, &vmbus_connection.chn_list, listentry) {
+		if (!uuid_le_cmp(channel->offermsg.offer.if_type,
+				 newchannel->offermsg.offer.if_type) &&
+		    !uuid_le_cmp(channel->offermsg.offer.if_instance,
+				 newchannel->offermsg.offer.if_instance)) {
+			fnew = false;
+			break;
+		}
+	}
+
+	if (fnew)
+		list_add_tail(&newchannel->listentry,
+			      &vmbus_connection.chn_list);
+	else {
+		/*
+ 		 * Check to see if this is a valid sub-channel.
+ 		 */
+		if (newchannel->offermsg.offer.sub_channel_index == 0) {
+			mutex_unlock(&vmbus_connection.channel_mutex);
+			/*
+ 			 * Don't call free_channel(), because newchannel->kobj
+ 			 * is not initialized yet.
+ 			 */
+			kfree(newchannel);
+			WARN_ON_ONCE(1);
+			return;
+		}
+		/*
+ 		 * Process the sub-channel.
+ 		 */
+		newchannel->primary_channel = channel;
+		spin_lock_irqsave(&channel->lock, flags);
+		list_add_tail(&newchannel->sc_list, &channel->sc_list);
+		spin_unlock_irqrestore(&channel->lock, flags);
+	}
+
+	mutex_unlock(&vmbus_connection.channel_mutex);
+
+	/*
+ 	 * vmbus_process_offer() mustn't call channel->sc_creation_callback()
+ 	 * directly for sub-channels, because sc_creation_callback() ->
+ 	 * vmbus_open() may never get the host's response to the
+  	 * OPEN_CHANNEL message (the host may rescind a channel at any time,
+  	 * e.g. in the case of hot removing a NIC), and vmbus_onoffer_rescind()
+  	 * may not wake up the vmbus_open() as it's blocked due to a non-zero
+  	 * vmbus_connection.offer_in_progress, and finally we have a deadlock.
+  	 *
+  	 * The above is also true for primary channels, if the related device
+  	 * drivers use sync probing mode by default.
+  	 *
+  	 * And, usually the handling of primary channels and sub-channels can
+  	 * depend on each other, so we should offload them to different
+  	 * workqueues to avoid possible deadlock, e.g. in sync-probing mode,
+  	 * NIC1's netvsc_subchan_work() can race with NIC2's netvsc_probe() ->
+  	 * rtnl_lock(), and causes deadlock: the former gets the rtnl_lock
+  	 * and waits for all the sub-channels to appear, but the latter
+  	 * can't get the rtnl_lock and this blocks the handling of
+  	 * sub-channels.
+  	 */
+	INIT_WORK(&newchannel->add_channel_work, vmbus_add_channel_work);
+	wq = fnew ? vmbus_connection.handle_primary_chan_wq :
+		    vmbus_connection.handle_sub_chan_wq;
+	queue_work(wq, &newchannel->add_channel_work);
 }
 
 /*
@@ -590,6 +648,14 @@ err_free_chan:
  */
 
 static int next_numa_node_id;
+
+/*
+ * init_vp_index() accesses global variables like next_numa_node_id, and
+ * it can run concurrently for primary channels and sub-channels: see
+ * vmbus_process_offer(), so we need the lock to protect the global
+ * variables.
+ */
+static DEFINE_SPINLOCK(bind_channel_to_cpu_lock);
 
 /*
  * Starting with Win8, we can statically distribute the incoming
@@ -622,6 +688,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 		channel->target_vp = hv_context.vp_index[0];
 		return;
 	}
+	spin_lock(&bind_channel_to_cpu_lock);
 
 	/*
 	 * Based on the channel affinity policy, we will assign the NUMA
@@ -653,7 +720,6 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 	         * reset the alloced map.
 	         */
 		cpumask_clear(alloced_mask);
-
         }
 
 	cpumask_xor(&available_mask, alloced_mask,
@@ -707,6 +773,7 @@ static void init_vp_index(struct vmbus_channel *channel, u16 dev_type)
 
 	channel->target_cpu = cur_cpu;
 	channel->target_vp = hv_context.vp_index[cur_cpu];
+	spin_unlock(&bind_channel_to_cpu_lock);
 }
 
 static void vmbus_wait_for_unload(void)
@@ -1238,48 +1305,6 @@ cleanup:
 	return ret;
 }
 
-/*
- * Retrieve the (sub) channel on which to send an outgoing request.
- * When a primary channel has multiple sub-channels, we try to
- * distribute the load equally amongst all available channels.
- */
-struct vmbus_channel *vmbus_get_outgoing_channel(struct vmbus_channel *primary)
-{
-	struct list_head *cur, *tmp;
-	int cur_cpu;
-	struct vmbus_channel *cur_channel;
-	struct vmbus_channel *outgoing_channel = primary;
-	int next_channel;
-	int i = 1;
-
-	if (list_empty(&primary->sc_list))
-		return outgoing_channel;
-
-	next_channel = primary->next_oc++;
-
-	if (next_channel > (primary->num_sc)) {
-		primary->next_oc = 0;
-		return outgoing_channel;
-	}
-
-	cur_cpu = hv_context.vp_index[get_cpu()];
-	put_cpu();
-	list_for_each_safe(cur, tmp, &primary->sc_list) {
-		cur_channel = list_entry(cur, struct vmbus_channel, sc_list);
-		if (cur_channel->state != CHANNEL_OPENED_STATE)
-			continue;
-
-		if (cur_channel->target_vp == cur_cpu)
-			return cur_channel;
-		if (i == next_channel)
-			return cur_channel;
-
-		i++;
-	}
-
-	return outgoing_channel;
-}
-EXPORT_SYMBOL_GPL(vmbus_get_outgoing_channel);
 
 static void invoke_sc_cb(struct vmbus_channel *primary_channel)
 {

--- a/hv-rhel6.x/hv/connection.c
+++ b/hv-rhel6.x/hv/connection.c
@@ -158,6 +158,20 @@ int vmbus_connect(void)
 		goto cleanup;
 	}
 
+	vmbus_connection.handle_primary_chan_wq =
+		create_workqueue("hv_pri_chan");
+	if (!vmbus_connection.handle_primary_chan_wq) {
+		ret = -ENOMEM;
+		goto cleanup;
+	}
+
+	vmbus_connection.handle_sub_chan_wq =
+		create_workqueue("hv_sub_chan");
+	if (!vmbus_connection.handle_sub_chan_wq) {
+		ret = -ENOMEM;
+		goto cleanup;
+	}
+
 	INIT_LIST_HEAD(&vmbus_connection.chn_msg_list);
 	spin_lock_init(&vmbus_connection.channelmsg_lock);
 
@@ -249,10 +263,20 @@ void vmbus_disconnect(void)
 	 */
 	vmbus_initiate_unload(false);
 
-	if (vmbus_connection.work_queue) {
-		flush_workqueue(vmbus_connection.work_queue);
-		destroy_workqueue(vmbus_connection.work_queue);
-	}
+        if (vmbus_connection.handle_sub_chan_wq){
+            flush_workqueue(vmbus_connection.handle_sub_chan_wq);
+            destroy_workqueue(vmbus_connection.handle_sub_chan_wq);
+        }		
+
+        if (vmbus_connection.handle_primary_chan_wq){
+            flush_workqueue(vmbus_connection.handle_primary_chan_wq);
+            destroy_workqueue(vmbus_connection.handle_primary_chan_wq);
+        }
+
+        if (vmbus_connection.work_queue){
+            flush_workqueue(vmbus_connection.work_queue);
+            destroy_workqueue(vmbus_connection.work_queue);
+        }  
 
 	if (vmbus_connection.int_page) {
 		free_pages((unsigned long)vmbus_connection.int_page, 0);

--- a/hv-rhel6.x/hv/hyperv_vmbus.h
+++ b/hv-rhel6.x/hv/hyperv_vmbus.h
@@ -367,7 +367,14 @@ struct vmbus_connection {
 	struct list_head chn_list;
 	struct mutex channel_mutex;
 
+	/*
+	 * An offer message is handled first on the work_queue, and then
+	 * is further handled on handle_primary_chan_wq or
+	 * handle_sub_chan_wq.
+	 */
 	struct workqueue_struct *work_queue;
+	struct workqueue_struct *handle_primary_chan_wq;
+	struct workqueue_struct *handle_sub_chan_wq;
 };
 
 
@@ -417,6 +424,8 @@ void vmbus_device_unregister(struct hv_device *device_obj);
 struct vmbus_channel *relid2channel(u32 relid);
 
 void vmbus_free_channels(void);
+
+int vmbus_add_channel_kobj(struct hv_device *dev, struct vmbus_channel *channel);
 
 /* Connection interface */
 

--- a/hv-rhel6.x/hv/vmbus_drv.c
+++ b/hv-rhel6.x/hv/vmbus_drv.c
@@ -107,6 +107,19 @@ static struct resource *fb_mmio;
 static struct resource *hyperv_mmio;
 static struct semaphore hyperv_mmio_lock;
 
+static u8 channel_monitor_group(const struct vmbus_channel *channel)
+{
+	return (u8)channel->offermsg.monitorid / 32;
+}
+
+static u32 channel_pending(const struct vmbus_channel *channel,
+			   const struct hv_monitor_page *monitor_page)
+{
+	u8 monitor_group = channel_monitor_group(channel);
+
+	return monitor_page->trigger_group[monitor_group].pending;
+}
+
 static int vmbus_exists(void)
 {
 	if (hv_acpi_dev == NULL)
@@ -166,6 +179,19 @@ static void get_channel_info(struct hv_device *device,
 		debug_info.outbound.bytes_avail_toread;
 	info->outbound.bytes_avail_towrite =
 		debug_info.outbound.bytes_avail_towrite;
+}
+static u8 channel_monitor_offset(const struct vmbus_channel *channel)
+{
+	return (u8)channel->offermsg.monitorid % 32;
+}
+
+static u32 channel_latency(const struct vmbus_channel *channel,
+			   const struct hv_monitor_page *monitor_page)
+{
+	u8 monitor_group = channel_monitor_group(channel);
+	u8 monitor_offset = channel_monitor_offset(channel);
+
+	return monitor_page->latency[monitor_group][monitor_offset];
 }
 
 /*
@@ -525,10 +551,165 @@ static struct bus_type  hv_bus = {
 static const char *driver_name = "hyperv";
 #endif
 
+
 struct onmessage_work_context {
 	struct work_struct work;
 	struct hv_message msg;
 };
+
+struct vmbus_chan_attribute {
+	struct attribute attr;
+	ssize_t (*show)(const struct vmbus_channel *chan, char *buf);
+	ssize_t (*store)(struct vmbus_channel *chan,
+			 const char *buf, size_t count);
+};
+
+/*
+ * Called when last reference to channel is gone.
+ */
+static void vmbus_chan_release(struct kobject *kobj)
+{
+	struct vmbus_channel *channel
+		= container_of(kobj, struct vmbus_channel, kobj);
+
+	kfree_rcu(channel, rcu);
+}
+
+#define VMBUS_CHAN_ATTR(_name, _mode, _show, _store) \
+	struct vmbus_chan_attribute chan_attr_##_name \
+		= __ATTR(_name, _mode, _show, _store)
+#define VMBUS_CHAN_ATTR_RW(_name) \
+	struct vmbus_chan_attribute chan_attr_##_name = __ATTR_RW(_name)
+#define VMBUS_CHAN_ATTR_RO(_name) \
+	struct vmbus_chan_attribute chan_attr_##_name = __ATTR_RO(_name)
+#define VMBUS_CHAN_ATTR_WO(_name) \
+	struct vmbus_chan_attribute chan_attr_##_name = __ATTR_WO(_name)
+
+static ssize_t out_mask_show(const struct vmbus_channel *channel, char *buf)
+{
+	const struct hv_ring_buffer_info *rbi = &channel->outbound;
+
+	return sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
+}
+static VMBUS_CHAN_ATTR_RO(out_mask);
+
+static ssize_t in_mask_show(const struct vmbus_channel *channel, char *buf)
+{
+	const struct hv_ring_buffer_info *rbi = &channel->inbound;
+
+	return sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
+}
+static VMBUS_CHAN_ATTR_RO(in_mask);
+
+static ssize_t read_avail_show(const struct vmbus_channel *channel, char *buf)
+{
+	const struct hv_ring_buffer_info *rbi = &channel->inbound;
+
+	return sprintf(buf, "%u\n", hv_get_bytes_to_read(rbi));
+}
+static VMBUS_CHAN_ATTR_RO(read_avail);
+
+static ssize_t write_avail_show(const struct vmbus_channel *channel, char *buf)
+{
+	const struct hv_ring_buffer_info *rbi = &channel->outbound;
+
+	return sprintf(buf, "%u\n", hv_get_bytes_to_write(rbi));
+}
+static VMBUS_CHAN_ATTR_RO(write_avail);
+
+static ssize_t show_target_cpu(const struct vmbus_channel *channel, char *buf)
+{
+	return sprintf(buf, "%u\n", channel->target_cpu);
+}
+static VMBUS_CHAN_ATTR(cpu, S_IRUGO, show_target_cpu, NULL);
+
+static ssize_t channel_pending_show(const struct vmbus_channel *channel,
+					char *buf)
+{
+	return sprintf(buf, "%d\n",
+			   channel_pending(channel,
+					   vmbus_connection.monitor_pages[1]));
+}
+static VMBUS_CHAN_ATTR(pending, S_IRUGO, channel_pending_show, NULL);
+
+static ssize_t channel_latency_show(const struct vmbus_channel *channel,
+					char *buf)
+{
+	return sprintf(buf, "%d\n",
+			   channel_latency(channel,
+					   vmbus_connection.monitor_pages[1]));
+}
+static VMBUS_CHAN_ATTR(latency, S_IRUGO, channel_latency_show, NULL);
+
+static ssize_t subchannel_monitor_id_show(const struct vmbus_channel *channel,
+					  char *buf)
+{
+	return sprintf(buf, "%u\n", channel->offermsg.monitorid);
+}
+static VMBUS_CHAN_ATTR(monitor_id, S_IRUGO, subchannel_monitor_id_show, NULL);
+
+static ssize_t subchannel_id_show(const struct vmbus_channel *channel,
+				  char *buf)
+{
+	return sprintf(buf, "%u\n",
+			   channel->offermsg.offer.sub_channel_index);
+}
+static VMBUS_CHAN_ATTR_RO(subchannel_id);
+static ssize_t vmbus_chan_attr_show(struct kobject *kobj,
+			    struct attribute *attr, char *buf)
+{
+	const struct vmbus_chan_attribute *attribute
+		= container_of(attr, struct vmbus_chan_attribute, attr);
+	const struct vmbus_channel *chan
+		= container_of(kobj, struct vmbus_channel, kobj);
+
+	if (!attribute->show)
+		return -EIO;
+
+	return attribute->show(chan, buf);
+}
+	static const struct sysfs_ops vmbus_chan_sysfs_ops = {
+		.show = vmbus_chan_attr_show,
+	};
+
+static struct attribute *vmbus_chan_attrs[] = {
+	&chan_attr_out_mask.attr,
+	&chan_attr_in_mask.attr,
+	&chan_attr_read_avail.attr,
+	&chan_attr_write_avail.attr,
+	&chan_attr_cpu.attr,
+	&chan_attr_pending.attr,
+	&chan_attr_latency.attr,
+	&chan_attr_monitor_id.attr,
+	&chan_attr_subchannel_id.attr,
+	NULL
+};
+
+static struct kobj_type vmbus_chan_ktype = {
+        .sysfs_ops = &vmbus_chan_sysfs_ops,
+        .release = vmbus_chan_release,
+        .default_attrs = vmbus_chan_attrs,
+};
+
+/*
+ * vmbus_add_channel_kobj - setup a sub-directory under device/channels
+ */
+int vmbus_add_channel_kobj(struct hv_device *dev, struct vmbus_channel *channel)
+{
+        struct kobject *kobj = &channel->kobj;
+        u32 relid = channel->offermsg.child_relid;
+        int ret;
+
+        kobj->kset = dev->channels_kset;
+        ret = kobject_init_and_add(kobj, &vmbus_chan_ktype, NULL,
+                                   "%u", relid);
+        if (ret)
+                return ret;
+
+        kobject_uevent(kobj, KOBJ_ADD);
+        printk("wmdsj:cpu:%d,dev_id:%x,ven_id:%x\n",smp_processor_id(),channel->device_id,channel->vendor_id);
+        return 0;
+}
 
 static void vmbus_onmessage_work(struct work_struct *work)
 {
@@ -769,6 +950,7 @@ static void vmbus_isr(void)
 #endif
 }
 
+
 #ifdef CONFIG_HOTPLUG_CPU
 static int hyperv_cpu_disable(void)
 {
@@ -988,6 +1170,7 @@ struct hv_device *vmbus_device_create(const uuid_le *type,
  */
 int vmbus_device_register(struct hv_device *child_device_obj)
 {
+	struct kobject *kobj = &child_device_obj->device.kobj;
 	int ret = 0;
 
 	dev_set_name(&child_device_obj->device, "%pUl",
@@ -1009,6 +1192,27 @@ int vmbus_device_register(struct hv_device *child_device_obj)
 		pr_debug("child device %s registered\n",
 			dev_name(&child_device_obj->device));
 
+	child_device_obj->channels_kset = kset_create_and_add("channels",
+							      NULL, kobj);
+	if (!child_device_obj->channels_kset) {
+		ret = -ENOMEM;
+		goto err_dev_unregister;
+	}
+
+	ret = vmbus_add_channel_kobj(child_device_obj,
+				     child_device_obj->channel);
+	if (ret) {
+		pr_err("Unable to register primary channeln");
+		goto err_kset_unregister;
+	}
+
+	return 0;
+
+err_kset_unregister:
+	kset_unregister(child_device_obj->channels_kset);
+
+err_dev_unregister:
+	device_unregister(&child_device_obj->device);
 	return ret;
 }
 


### PR DESCRIPTION
RH6: to backport upstream 2 patches: to remove the useless API vmbus_get_outgoing_channel(), and to offload the handling of channels to two workqueues. In the process, vmbus_add_channel_kobj( ) api is invoked; as a result, in /sys/bus/vmbus/devices/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/  a directory of channels/ is generated, which includes cpu  in_mask  latency  monitor_id  out_mask  pending  read_avail  subchannel_id  write_avail items. These features are tested in redhat6.10 by disconnecting NICs, enabling/disabling sriov and so on. These tests are all pass.