### PR TITLE
RH6: hv_netvsc: remove VF in flight counters

### DIFF
--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -910,8 +910,6 @@ struct net_device_context {
 
 	/* State to manage the associated VF interface. */
 	struct net_device *vf_netdev;
-	bool vf_inject;
-	atomic_t vf_use_cnt;
 
 	struct netvsc_vf_pcpu_stats __percpu *vf_stats;
 	struct work_struct vf_takeover;


### PR DESCRIPTION
Backport of RH7 commit: 673694263aa999e55500ab57ad4621646b6bb69a
This fixes warning "function netvsc_inject_enable defined but not used".