### PR TITLE
RH6: netvsc: Increament master if stats with slave VF if stats

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -300,8 +300,11 @@ static int netvsc_vf_xmit(struct net_device *net, struct net_device *vf_netdev,
 		pcpu_stats->tx_packets++;
 		pcpu_stats->tx_bytes += len;
 		u64_stats_update_end(&pcpu_stats->syncp);
+		net->stats.tx_packets++;
+		net->stats.tx_bytes += len;
 	} else {
 		this_cpu_inc(ndev_ctx->vf_stats->tx_dropped);
+		net->stats.tx_dropped++;
 	}
 
 	return rc;
@@ -534,6 +537,8 @@ static rx_handler_result_t netvsc_vf_handle_frame(struct sk_buff **pskb)
 	pcpu_stats->rx_packets++;
 	pcpu_stats->rx_bytes += skb->len;
 	u64_stats_update_end(&pcpu_stats->syncp);
+	ndev->stats.rx_packets++;
+	ndev->stats.rx_bytes += skb->len;
 
 	return RX_HANDLER_ANOTHER;
 }


### PR DESCRIPTION
This fixes ifconfig statistics issue seen in RH6x after implementing transparent sriov.

Code added to increment master synthetic interface stats for stats increment of slave VF interface.
This will make behavior similar to what we seen RH7x. 