### PR TITLE
Fix for bug 20102263 - Crash was observed in RH6.X

### DIFF
--- a/hv-rhel6.x/hv/ring_buffer.c
+++ b/hv-rhel6.x/hv/ring_buffer.c
@@ -217,6 +217,7 @@ int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
 void hv_ringbuffer_cleanup(struct hv_ring_buffer_info *ring_info)
 {
 	vunmap(ring_info->ring_buffer);
+	ring_info->ring_buffer = NULL;
 }
 
 /* Write to the ring buffer */


### PR DESCRIPTION
When hv_netvsc module is unloaded using modprobe and lsvmbus utility is executed, a crash was observed. Now the issue is fixed.