### PR TITLE
RH6: Add support for PCI protocol version 1.2

### DIFF
--- a/hv-rhel6.x/hv/arch/x86/include/uapi/lis/asm/hyperv.h
+++ b/hv-rhel6.x/hv/arch/x86/include/uapi/lis/asm/hyperv.h
@@ -151,6 +151,11 @@
 #define HV_X64_DEPRECATING_AEOI_RECOMMENDED	(1 << 9)
 
 /*
+ * HV_VP_SET available
+ */
+#define HV_X64_EX_PROCESSOR_MASKS_RECOMMENDED	(1 < 11)
+
+/*
  * Crash notification flag.
  */
 #define HV_CRASH_CTL_CRASH_NOTIFY (1ULL << 63)


### PR DESCRIPTION
This is backport of these RH7 commits:

16370f95df2890bf2ef884b970f3d58558312b2e
679cd43cbddd6d63f1ba001a055be6f78cc74b79
fe4bfc622be20380da0da02c81568a582304a512