### PR TITLE
RH6: hv: vmbus: Remove the useless API vmbus_get_outgoing_channel()

### DIFF
--- a/hv-rhel6.x/hv/channel_mgmt.c
+++ b/hv-rhel6.x/hv/channel_mgmt.c
@@ -419,7 +419,6 @@ void hv_process_channel_removal(u32 relid)
 		primary_channel = channel->primary_channel;
 		spin_lock_irqsave(&primary_channel->lock, flags);
 		list_del(&channel->sc_list);
-		primary_channel->num_sc--;
 		spin_unlock_irqrestore(&primary_channel->lock, flags);
 	}
 
@@ -498,7 +497,6 @@ static void vmbus_process_offer(struct vmbus_channel *newchannel)
 			newchannel->primary_channel = channel;
 			spin_lock_irqsave(&channel->lock, flags);
 			list_add_tail(&newchannel->sc_list, &channel->sc_list);
-			channel->num_sc++;
 			spin_unlock_irqrestore(&channel->lock, flags);
 		} else {
 			goto err_free_chan;
@@ -1237,49 +1235,6 @@ cleanup:
 
 	return ret;
 }
-
-/*
- * Retrieve the (sub) channel on which to send an outgoing request.
- * When a primary channel has multiple sub-channels, we try to
- * distribute the load equally amongst all available channels.
- */
-struct vmbus_channel *vmbus_get_outgoing_channel(struct vmbus_channel *primary)
-{
-	struct list_head *cur, *tmp;
-	int cur_cpu;
-	struct vmbus_channel *cur_channel;
-	struct vmbus_channel *outgoing_channel = primary;
-	int next_channel;
-	int i = 1;
-
-	if (list_empty(&primary->sc_list))
-		return outgoing_channel;
-
-	next_channel = primary->next_oc++;
-
-	if (next_channel > (primary->num_sc)) {
-		primary->next_oc = 0;
-		return outgoing_channel;
-	}
-
-	cur_cpu = hv_context.vp_index[get_cpu()];
-	put_cpu();
-	list_for_each_safe(cur, tmp, &primary->sc_list) {
-		cur_channel = list_entry(cur, struct vmbus_channel, sc_list);
-		if (cur_channel->state != CHANNEL_OPENED_STATE)
-			continue;
-
-		if (cur_channel->target_vp == cur_cpu)
-			return cur_channel;
-		if (i == next_channel)
-			return cur_channel;
-
-		i++;
-	}
-
-	return outgoing_channel;
-}
-EXPORT_SYMBOL_GPL(vmbus_get_outgoing_channel);
 
 static void invoke_sc_cb(struct vmbus_channel *primary_channel)
 {

--- a/hv-rhel6.x/hv/include/linux/hyperv.h
+++ b/hv-rhel6.x/hv/include/linux/hyperv.h
@@ -865,15 +865,6 @@ struct vmbus_channel {
 	struct list_head sc_list;
 
 	/*
-	 * Current number of sub-channels.
-	 */
-	int num_sc;
-	/*
-	 * Number of a sub-channel (position within sc_list) which is supposed
-	 * to be used as the next outgoing channel.
-	 */
-	int next_oc;
-	/*
 	 * The primary channel this sub-channel belongs to.
 	 * This will be NULL for the primary channel.
 	 */
@@ -986,14 +977,6 @@ void vmbus_set_sc_create_callback(struct vmbus_channel *primary_channel,
 
 void vmbus_set_chn_rescind_callback(struct vmbus_channel *channel,
 			void (*sc_cr_cb)(struct vmbus_channel *new_sc));
-
-/*
- * Retrieve the (sub) channel on which to send an outgoing request.
- * When a primary channel has multiple sub-channels, we choose a
- * channel whose VCPU binding is closest to the VCPU on which
- * this call is being made.
- */
-struct vmbus_channel *vmbus_get_outgoing_channel(struct vmbus_channel *primary);
 
 /*
  * Check if sub-channels have already been offerred. This API will be useful


### PR DESCRIPTION
Backported from RH7: SHA: ca51a433ee97bb03a9cfdb72cd826a9529c4196a