### PR TITLE
RH6: hv_netvsc: fix network namespace issues with VF support

### DIFF
--- a/hv-rhel6.x/hv/hyperv_net.h
+++ b/hv-rhel6.x/hv/hyperv_net.h
@@ -883,6 +883,8 @@ struct net_device_context {
 	struct hv_device *device_ctx;
 	/* netvsc_device */
 	struct netvsc_device *nvdev;
+	/* list of netvsc net_devices */
+	struct list_head list;
 	/* reconfigure work */
 	struct delayed_work dwork;
 	/* last reconfig time */


### PR DESCRIPTION
Backported from RH7. SHA: b41831531ae57d28e7114056cbced5e34f94f5a2
On top of backport new modification was added to support the device name
allocation as it was done in register_netdev() in RH6 kernel