### PR TITLE
RH6: PCI: hv: Fix wslot_to_devfn() to fix warnings on device removal

### DIFF
--- a/hv-rhel6.x/hv/pci-hyperv.c
+++ b/hv-rhel6.x/hv/pci-hyperv.c
@@ -155,7 +155,8 @@ union pci_version {
  */
 union win_slot_encoding {
 	struct {
-		u32	func:8;
+		u32     dev:5;
+		u32     func:3;
 		u32	reserved:24;
 	} bits;
 	u32 slot;
@@ -580,7 +581,8 @@ static u32 devfn_to_wslot(int devfn)
 	union win_slot_encoding wslot;
 
 	wslot.slot = 0;
-	wslot.bits.func = PCI_SLOT(devfn) | (PCI_FUNC(devfn) << 5);
+	wslot.bits.dev = PCI_SLOT(devfn);
+	wslot.bits.func = PCI_FUNC(devfn);
 
 	return wslot.slot;
 }
@@ -598,7 +600,7 @@ static int wslot_to_devfn(u32 wslot)
 	union win_slot_encoding slot_no;
 
 	slot_no.slot = wslot;
-	return PCI_DEVFN(0, slot_no.bits.func);
+	return PCI_DEVFN(slot_no.bits.dev, slot_no.bits.func);
 }
 
 /*


### PR DESCRIPTION
Backported from RH7: SHA:16edc0c054b6f8f8d298847739ea06bca604b1d3