### PR TITLE
RH6: hv_netvsc: move VF to same namespace as netvsc device

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -1702,6 +1702,7 @@ static int netvsc_register_vf(struct net_device *vf_netdev)
 	struct net_device *ndev;
 	struct net_device_context *net_device_ctx;
 	struct netvsc_device *netvsc_dev;
+	int ret;
 
 	if (vf_netdev->addr_len != ETH_ALEN)
 		return NOTIFY_DONE;
@@ -1724,10 +1725,32 @@ static int netvsc_register_vf(struct net_device *vf_netdev)
 #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(6,7))
 	net_device_ctx->vf_netdev = vf_netdev;
 
+	/* if syntihetic interface is a different namespace,
+	 * then move the VF to that namespace; join will be
+	 * done again in that context.
+	 */
+	if (!net_eq(dev_net(ndev), dev_net(vf_netdev))) {
+		ret = dev_change_net_namespace(vf_netdev,
+					       dev_net(ndev), "eth%d");
+		if (ret)
+			netdev_err(vf_netdev,
+				   "could not move to same namespace as %s: %d\n",
+				   ndev->name, ret);
+		else
+			netdev_info(vf_netdev,
+				    "VF moved to namespace with: %s\n",
+				    ndev->name);
+
+		return NOTIFY_DONE;
+}
+#endif
+	netdev_info(ndev, "VF registering: %s\n", vf_netdev->name);
+
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(6,7))
 	if (netvsc_vf_join(vf_netdev, ndev) != 0)
 		return NOTIFY_DONE;
 #endif
-	netdev_info(ndev, "VF registering: %s\n", vf_netdev->name);
+
 	/*
 	 * Take a reference on the module.
 	 */


### PR DESCRIPTION
This is a backport RH7 commit e929d12149f4355c8a6eea40f73963fa6c05e245

This doesn't fix any current issue.
I did this for some other purpose and I think it is good to have it.