### PR TITLE
RH6: Handle congestion notification from dev_queue_xmit

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -305,6 +305,9 @@ static int netvsc_vf_xmit(struct net_device *net, struct net_device *vf_netdev,
 		net->stats.tx_dropped++;
 	}
 
+	if (rc > 0)
+		rc = net_xmit_errno(rc);
+
 	return rc;
 }
 


### PR DESCRIPTION
This prevents a crash that occurs during hot enable of SRIOV while ntttcp test is ongoing.
