### PR TITLE
RH7: hv_netvsc: ignore devices that are not PCI

### DIFF
--- a/hv-rhel7.x/hv/netvsc_drv.c
+++ b/hv-rhel7.x/hv/netvsc_drv.c
@@ -29,6 +29,7 @@
 #include <linux/netdevice.h>
 #include <linux/inetdevice.h>
 #include <linux/etherdevice.h>
+#include <linux/pci.h>
 #include <linux/skbuff.h>
 #include <linux/if_vlan.h>
 #include <linux/in.h>
@@ -2132,11 +2133,15 @@ static struct net_device *get_netvsc_byslot(const struct net_device *vf_netdev)
 static int netvsc_register_vf(struct net_device *vf_netdev)
 {
 	struct net_device_context *net_device_ctx;
+	struct device *pdev = vf_netdev->dev.parent;
 	struct netvsc_device *netvsc_dev;
 	struct net_device *ndev;
 	int ret;
 
 	if (vf_netdev->addr_len != ETH_ALEN)
+		return NOTIFY_DONE;
+
+	if (!pdev || !dev_is_pci(pdev) || dev_is_pf(pdev))
 		return NOTIFY_DONE;
 
 	ndev = get_netvsc_byslot(vf_netdev);


### PR DESCRIPTION
This is backport of upstream commit:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=b93c1b5ac8643cc08bb74fa8ae21d6c63dfcb23d