### PR TITLE
RH7: hv_fcopy: set 'error' in case an unknown operation was requested

### DIFF
--- a/hv-rhel7.x/hv/tools/hv_fcopy_daemon.c
+++ b/hv-rhel7.x/hv/tools/hv_fcopy_daemon.c
@@ -234,6 +234,7 @@ int main(int argc, char *argv[])
 			break;
 
 		default:
+			error = HV_E_FAIL;
 			syslog(LOG_ERR, "Unknown operation: %d",
 				buffer.hdr.operation);
 


### PR DESCRIPTION
This is backport of upstream commit:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=c2d68afba86d1ff01e7300c68bc16a9234dcd8e9