### PR TITLE
RH6: Handle negative returns from dev_queue_xmit

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -308,6 +308,9 @@ static int netvsc_vf_xmit(struct net_device *net, struct net_device *vf_netdev,
 	if (rc > 0)
 		rc = net_xmit_errno(rc);
 
+	if (rc < 0)
+		rc = NETDEV_TX_OK;
+
 	return rc;
 }
 


### PR DESCRIPTION
This prevents a general protection fault crash seen during ntttcp udp test.