### PR TITLE
RH6: Remove checks netif_queue_stopped() & in_serving_softirq()

### DIFF
--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -567,8 +567,7 @@ static int netvsc_start_xmit(struct sk_buff *skb, struct net_device *net)
 	 */
 	vf_netdev = rcu_dereference_bh(net_device_ctx->vf_netdev);
 	if (vf_netdev && netif_running(vf_netdev) &&
-		!netpoll_tx_running(net) && !in_serving_softirq() &&
-		!netif_queue_stopped(vf_netdev)) {
+		!netpoll_tx_running(net)) {
 		return netvsc_vf_xmit(net, vf_netdev, skb);
 	}
 #endif


### PR DESCRIPTION
These checks are no longer required after the fix made in
commit: 96e7f128a1a5bace2c8988e293c0cd9523d5d739