### PR TITLE
RH7: PCI: hv: Fix return value check in hv_pci_assign_slots

### DIFF
--- a/hv-rhel7.x/hv/pci-hyperv.c
+++ b/hv-rhel7.x/hv/pci-hyperv.c
@@ -1372,8 +1372,10 @@ static void hv_pci_assign_slots(struct hv_pcibus_device *hbus)
 		snprintf(name, SLOT_NAME_SIZE, "%u", hpdev->desc.ser);
 		hpdev->pci_slot = pci_create_slot(hbus->pci_bus, slot_nr,
 					  name, NULL);
-		if (!hpdev->pci_slot)
+		if (IS_ERR(hpdev->pci_slot)) {
 			pr_warn("pci_create slot %s failed\n", name);
+			hpdev->pci_slot = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
Backported from: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=54be5b8ce33f8d1a05b258070c81ed98f935883d