### PR TITLE
RH7: Drivers: hv: vmbus: Use get/put_cpu() in vmbus_connect()

### DIFF
--- a/hv-rhel7.x/hv/connection.c
+++ b/hv-rhel7.x/hv/connection.c
@@ -77,6 +77,7 @@ static int vmbus_negotiate_version(struct vmbus_channel_msginfo *msginfo,
 					__u32 version)
 {
 	int ret = 0;
+	unsigned int cur_cpu;
 	struct vmbus_channel_initiate_contact *msg;
 	unsigned long flags;
 
@@ -119,9 +120,10 @@ static int vmbus_negotiate_version(struct vmbus_channel_msginfo *msginfo,
          * the CPU attempting to connect may not be CPU 0.
          */
         if (version >= VERSION_WIN8_1) {
-		msg->target_vcpu =
-			hv_cpu_number_to_vp_number(smp_processor_id());
-		vmbus_connection.connect_cpu = smp_processor_id();
+		cur_cpu = get_cpu();
+		msg->target_vcpu = hv_cpu_number_to_vp_number(cur_cpu);
+		vmbus_connection.connect_cpu = cur_cpu;
+		put_cpu();
 		} else {
                 msg->target_vcpu = 0;
 				vmbus_connection.connect_cpu = 0;


### PR DESCRIPTION
This is backport of upstream commit:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=41e270f6898e7502be9fd6920ee0a108ca259d36