### PR TITLE
Revert "RH7: PCI: hv: Make sure the bus domain is really unique"

### DIFF
--- a/hv-rhel7.x/hv/pci-hyperv.c
+++ b/hv-rhel7.x/hv/pci-hyperv.c
@@ -1507,6 +1507,19 @@ static struct hv_pci_dev *new_pcichild_device(struct hv_pcibus_device *hbus,
 	get_pcichild(hpdev, hv_pcidev_ref_initial);
 	get_pcichild(hpdev, hv_pcidev_ref_childlist);
 	spin_lock_irqsave(&hbus->device_list_lock, flags);
+	/*
+	 * When a device is being added to the bus, we set the PCI domain
+	 * number to be the device serial number, which is non-zero and
+	 * unique on the same VM.  The serial numbers start with 1, and
+	 * increase by 1 for each device.  So device names including this
+	 * can have shorter names than based on the bus instance UUID.
+	 * Only the first device serial number is used for domain, so the
+	 * domain number will not change after the first device is added.
+	 * The lower 16 bits of the serial number is used, otherwise some
+	 * drivers may not be able to handle it.
+	 */
+	if (list_empty(&hbus->children))
+		hbus->sysdata.domain = desc->ser & 0xFFFF;
 	list_add_tail(&hpdev->list_entry, &hbus->children);
 	spin_unlock_irqrestore(&hbus->device_list_lock, flags);
 	return hpdev;


### PR DESCRIPTION
This reverts commit 636fd886122a020abc0f715d41befb5fc8c32ed4.

(cherry picked from commit c4e45f46e93f1b5bd99bcef447883437da23b422)