### PR TITLE
RH7: hv_utils: update name in struct hv_driver util_drv

### DIFF
--- a/hv-rhel7.x/hv/hv_util.c
+++ b/hv-rhel7.x/hv/hv_util.c
@@ -483,7 +483,7 @@ MODULE_DEVICE_TABLE(vmbus, id_table);
 
 /* The one and only one */
 static  struct hv_driver util_drv = {
-	.name = "hv_util",
+	.name = "hv_utils",
 	.id_table = id_table,
 	.probe =  util_probe,
 	.remove =  util_remove,


### PR DESCRIPTION
Backporting from: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=5c24ee897664822956b1830df6957bb7f8965bb3