### PR TITLE
RH7: hv: kvp: Use %u to print U32

### DIFF
--- a/hv-rhel7.x/hv/hv_kvp.c
+++ b/hv-rhel7.x/hv/hv_kvp.c
@@ -438,7 +438,7 @@ kvp_send_key(struct work_struct *dummy)
 			val32 = in_msg->body.kvp_set.data.value_u32;
 			message->body.kvp_set.data.value_size =
 				sprintf(message->body.kvp_set.data.value,
-					"%d", val32) + 1;
+					"%u", val32) + 1;
 			break;
 
 		case REG_U64:


### PR DESCRIPTION
Backporting from: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=16d1342bc41ad417812f8a800a1799b5d1c026dc