### PR TITLE
RH7: Input: hyper-v - fix wakeup from suspend-to-idle

### DIFF
--- a/hv-rhel7.x/hv/hid-hyperv.c
+++ b/hv-rhel7.x/hv/hid-hyperv.c
@@ -309,7 +309,7 @@ static void mousevsc_on_receive(struct hv_device *device,
 		hid_input_report(input_dev->hid_device, HID_INPUT_REPORT,
 				 input_dev->input_buf, len, 1);
 
-		pm_wakeup_event(&input_dev->device->device, 0);
+		pm_wakeup_hard_event(&input_dev->device->device);
 
 		break;
 	default:

--- a/hv-rhel7.x/hv/hyperv-keyboard.c
+++ b/hv-rhel7.x/hv/hyperv-keyboard.c
@@ -177,7 +177,7 @@ static void hv_kbd_on_receive(struct hv_device *hv_dev,
 		 * state because the Enter-UP can trigger a wakeup at once.
 		 */
 		if (!(info & IS_BREAK))
-			pm_wakeup_event(&hv_dev->device, 0);
+			pm_wakeup_hard_event(&hv_dev->device);
 
 		break;
 


### PR DESCRIPTION
This is a backport of upstream:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=10f91c73cc41ceead210a905dbd196398e99c7d2