### PR TITLE
RH7: hv_netvsc: fix typos in code comments

### DIFF
--- a/hv-rhel7.x/hv/hyperv_net.h
+++ b/hv-rhel7.x/hv/hyperv_net.h
@@ -1185,7 +1185,7 @@ enum ndis_per_pkt_info_type {
 
 enum rndis_per_pkt_info_interal_type {
 	RNDIS_PKTINFO_ID = 1,
-	/* Add more memebers here */
+	/* Add more members here */
 
 	RNDIS_PKTINFO_MAX
 };

--- a/hv-rhel7.x/hv/netvsc.c
+++ b/hv-rhel7.x/hv/netvsc.c
@@ -1380,7 +1380,7 @@ void netvsc_channel_cb(void *context)
 	prefetch(hv_get_ring_buffer(rbi) + rbi->priv_read_index);
 
 	if (napi_schedule_prep(&nvchan->napi)) {
-		/* disable interupts from host */
+		/* disable interrupts from host */
 		hv_begin_read(rbi);
 
 		__napi_schedule_irqoff(&nvchan->napi);

--- a/hv-rhel7.x/hv/netvsc_drv.c
+++ b/hv-rhel7.x/hv/netvsc_drv.c
@@ -443,7 +443,7 @@ static u32 fill_pg_buf(struct page *page, u32 offset, u32 len,
 {
 	int j = 0;
 
-	/* Deal with compund pages by ignoring unused part
+	/* Deal with compound pages by ignoring unused part
 	 * of the page.
 	 */
 	page += (offset >> PAGE_SHIFT);
@@ -2207,7 +2207,7 @@ static int netvsc_register_vf(struct net_device *vf_netdev)
 	if (!netvsc_dev || rtnl_dereference(net_device_ctx->vf_netdev))
 		return NOTIFY_DONE;
 
-	/* if syntihetic interface is a different namespace,
+	/* if synthetic interface is a different namespace,
 	 * then move the VF to that namespace; join will be
 	 * done again in that context.
 	 */
@@ -2355,7 +2355,7 @@ static int netvsc_probe(struct hv_device *dev,
 	 * netvsc_probe() can't get rtnl lock and as a result vmbus_onoffer()
 	 * -> ... -> device_add() -> ... -> __device_attach() can't get
 	 * the device lock, so all the subchannels can't be processed --
-	 * finally netvsc_subchan_work() hangs for ever.
+	 * finally netvsc_subchan_work() hangs forever.
 	 */
 	rtnl_lock();
 


### PR DESCRIPTION
Backported from upstream:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=52d3b4949192e93b948daaa40678fcd4b94bcbd0