### PR TITLE
Revert "RH7: Drivers: hv: vmbus: Fix race condition with new ring_buffer_info mutex"

### DIFF
--- a/hv-rhel7.x/hv/channel_mgmt.c
+++ b/hv-rhel7.x/hv/channel_mgmt.c
@@ -344,8 +344,6 @@ static struct vmbus_channel *alloc_channel(void)
 	tasklet_init(&channel->callback_event,
 		     vmbus_on_event, (unsigned long)channel);
 
-	hv_ringbuffer_pre_init(channel);
-
 	return channel;
 }
 

--- a/hv-rhel7.x/hv/hyperv_vmbus.h
+++ b/hv-rhel7.x/hv/hyperv_vmbus.h
@@ -275,7 +275,6 @@ extern int hv_synic_cpu_used(unsigned int cpu);
 
 /* Interface */
 
-void hv_ringbuffer_pre_init(struct vmbus_channel *channel);
 
 int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
 		       struct page *pages, u32 pagecnt);

--- a/hv-rhel7.x/hv/include/linux/hyperv.h
+++ b/hv-rhel7.x/hv/include/linux/hyperv.h
@@ -148,11 +148,6 @@ struct hv_ring_buffer_info {
 
 	u32 ring_datasize;		/* < ring_size */
 	u32 priv_read_index;
-	/*
-	 * The ring buffer mutex lock. This lock prevents the ring buffer from
-	 * being freed while the ring buffer is being accessed.
-	 */
-	struct mutex ring_buffer_mutex;
 };
 
 
@@ -1227,7 +1222,7 @@ struct hv_ring_buffer_debug_info {
 };
 
 
-int hv_ringbuffer_get_debuginfo(struct hv_ring_buffer_info *ring_info,
+int hv_ringbuffer_get_debuginfo(const struct hv_ring_buffer_info *ring_info,
 				struct hv_ring_buffer_debug_info *debug_info);
 
 /* Vmbus interface */

--- a/hv-rhel7.x/hv/ring_buffer.c
+++ b/hv-rhel7.x/hv/ring_buffer.c
@@ -164,18 +164,14 @@ hv_get_ringbuffer_availbytes(const struct hv_ring_buffer_info *rbi,
 }
 
 /* Get various debug metrics for the specified ring buffer */
-int hv_ringbuffer_get_debuginfo(struct hv_ring_buffer_info *ring_info,
+int hv_ringbuffer_get_debuginfo(const struct hv_ring_buffer_info *ring_info,
 				struct hv_ring_buffer_debug_info *debug_info)
 {
 	u32 bytes_avail_towrite;
 	u32 bytes_avail_toread;
 
-	mutex_lock(&ring_info->ring_buffer_mutex);
-
-	if (!ring_info->ring_buffer) {
-		mutex_unlock(&ring_info->ring_buffer_mutex);
+	if (!ring_info->ring_buffer)
 		return -EINVAL;
-	}
 
 	hv_get_ringbuffer_availbytes(ring_info,
 				     &bytes_avail_toread,
@@ -186,18 +182,10 @@ int hv_ringbuffer_get_debuginfo(struct hv_ring_buffer_info *ring_info,
 	debug_info->current_write_index = ring_info->ring_buffer->write_index;
 	debug_info->current_interrupt_mask
 		= ring_info->ring_buffer->interrupt_mask;
-	mutex_unlock(&ring_info->ring_buffer_mutex);
-
 	return 0;
 }
 EXPORT_SYMBOL_GPL(hv_ringbuffer_get_debuginfo);
 
-/* Initialize a channel's ring buffer info mutex locks */
-void hv_ringbuffer_pre_init(struct vmbus_channel *channel)
-{
-	mutex_init(&channel->inbound.ring_buffer_mutex);
-	mutex_init(&channel->outbound.ring_buffer_mutex);
-}
 
 /* Initialize the ring buffer. */
 int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
@@ -250,10 +238,8 @@ int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
 /* Cleanup the ring buffer */
 void hv_ringbuffer_cleanup(struct hv_ring_buffer_info *ring_info)
 {
-	mutex_lock(&ring_info->ring_buffer_mutex);
 	vunmap(ring_info->ring_buffer);
 	ring_info->ring_buffer = NULL;
-	mutex_unlock(&ring_info->ring_buffer_mutex);
 }
 
 /* Write to the ring buffer */

--- a/hv-rhel7.x/hv/vmbus_drv.c
+++ b/hv-rhel7.x/hv/vmbus_drv.c
@@ -1679,7 +1679,7 @@ static void vmbus_chan_release(struct kobject *kobj)
 
 struct vmbus_chan_attribute {
 	struct attribute attr;
-	ssize_t (*show)(struct vmbus_channel *chan, char *buf);
+	ssize_t (*show)(const struct vmbus_channel *chan, char *buf);
 	ssize_t (*store)(struct vmbus_channel *chan,
 			 const char *buf, size_t count);
 };
@@ -1698,7 +1698,7 @@ static ssize_t vmbus_chan_attr_show(struct kobject *kobj,
 {
 	const struct vmbus_chan_attribute *attribute
 		= container_of(attr, struct vmbus_chan_attribute, attr);
-	struct vmbus_channel *chan
+	const struct vmbus_channel *chan
 		= container_of(kobj, struct vmbus_channel, kobj);
 
 	if (!attribute->show)
@@ -1711,81 +1711,57 @@ static const struct sysfs_ops vmbus_chan_sysfs_ops = {
 	.show = vmbus_chan_attr_show,
 };
 
-static ssize_t out_mask_show(struct vmbus_channel *channel, char *buf)
+static ssize_t out_mask_show(const struct vmbus_channel *channel, char *buf)
 {
-	struct hv_ring_buffer_info *rbi = &channel->outbound;
-	ssize_t ret;
+	const struct hv_ring_buffer_info *rbi = &channel->outbound;
 
-	mutex_lock(&rbi->ring_buffer_mutex);
-	if (!rbi->ring_buffer) {
-		mutex_unlock(&rbi->ring_buffer_mutex);
+	if (!rbi->ring_buffer)
 		return -EINVAL;
-	}
 
-	ret = sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
-	mutex_unlock(&rbi->ring_buffer_mutex);
-	return ret;
+	return sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
 }
 static VMBUS_CHAN_ATTR_RO(out_mask);
 
-static ssize_t in_mask_show(struct vmbus_channel *channel, char *buf)
+static ssize_t in_mask_show(const struct vmbus_channel *channel, char *buf)
 {
-	struct hv_ring_buffer_info *rbi = &channel->inbound;
-	ssize_t ret;
+	const struct hv_ring_buffer_info *rbi = &channel->inbound;
 
-	mutex_lock(&rbi->ring_buffer_mutex);
-	if (!rbi->ring_buffer) {
-		mutex_unlock(&rbi->ring_buffer_mutex);
+	if (!rbi->ring_buffer)
 		return -EINVAL;
-	}
 
-	ret = sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
-	mutex_unlock(&rbi->ring_buffer_mutex);
-	return ret;
+	return sprintf(buf, "%u\n", rbi->ring_buffer->interrupt_mask);
 }
 static VMBUS_CHAN_ATTR_RO(in_mask);
 
-static ssize_t read_avail_show(struct vmbus_channel *channel, char *buf)
+static ssize_t read_avail_show(const struct vmbus_channel *channel, char *buf)
 {
-	struct hv_ring_buffer_info *rbi = &channel->inbound;
-	ssize_t ret;
+	const struct hv_ring_buffer_info *rbi = &channel->inbound;
 
-	mutex_lock(&rbi->ring_buffer_mutex);
-	if (!rbi->ring_buffer) {
-		mutex_unlock(&rbi->ring_buffer_mutex);
+	if (!rbi->ring_buffer)
 		return -EINVAL;
-	}
 
-	ret = sprintf(buf, "%u\n", hv_get_bytes_to_read(rbi));
-	mutex_unlock(&rbi->ring_buffer_mutex);
-	return ret;
+	return sprintf(buf, "%u\n", hv_get_bytes_to_read(rbi));
 }
 static VMBUS_CHAN_ATTR_RO(read_avail);
 
-static ssize_t write_avail_show(struct vmbus_channel *channel, char *buf)
+static ssize_t write_avail_show(const struct vmbus_channel *channel, char *buf)
 {
-	struct hv_ring_buffer_info *rbi = &channel->outbound;
-	ssize_t ret;
+	const struct hv_ring_buffer_info *rbi = &channel->outbound;
 
-	mutex_lock(&rbi->ring_buffer_mutex);
-	if (!rbi->ring_buffer) {
-		mutex_unlock(&rbi->ring_buffer_mutex);
+	if (!rbi->ring_buffer)
 		return -EINVAL;
-	}
 
-	ret = sprintf(buf, "%u\n", hv_get_bytes_to_write(rbi));
-	mutex_unlock(&rbi->ring_buffer_mutex);
-	return ret;
+	return sprintf(buf, "%u\n", hv_get_bytes_to_write(rbi));
 }
 static VMBUS_CHAN_ATTR_RO(write_avail);
 
-static ssize_t show_target_cpu(struct vmbus_channel *channel, char *buf)
+static ssize_t show_target_cpu(const struct vmbus_channel *channel, char *buf)
 {
 	return sprintf(buf, "%u\n", channel->target_cpu);
 }
 static VMBUS_CHAN_ATTR(cpu, S_IRUGO, show_target_cpu, NULL);
 
-static ssize_t channel_pending_show(struct vmbus_channel *channel,
+static ssize_t channel_pending_show(const struct vmbus_channel *channel,
 				    char *buf)
 {
 	return sprintf(buf, "%d\n",
@@ -1794,7 +1770,7 @@ static ssize_t channel_pending_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(pending, S_IRUGO, channel_pending_show, NULL);
 
-static ssize_t channel_latency_show(struct vmbus_channel *channel,
+static ssize_t channel_latency_show(const struct vmbus_channel *channel,
 				    char *buf)
 {
 	return sprintf(buf, "%d\n",
@@ -1803,7 +1779,7 @@ static ssize_t channel_latency_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(latency, S_IRUGO, channel_latency_show, NULL);
 
-static ssize_t channel_intr_in_full_show(struct vmbus_channel *channel,
+static ssize_t channel_intr_in_full_show(const struct vmbus_channel *channel,
 					 char *buf)
 {
 	return sprintf(buf, "%llu\n",
@@ -1811,7 +1787,7 @@ static ssize_t channel_intr_in_full_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(intr_in_full, 0444, channel_intr_in_full_show, NULL);
 
-static ssize_t channel_intr_out_empty_show(struct vmbus_channel *channel,
+static ssize_t channel_intr_out_empty_show(const struct vmbus_channel *channel,
 					   char *buf)
 {
 	return sprintf(buf, "%llu\n",
@@ -1819,7 +1795,7 @@ static ssize_t channel_intr_out_empty_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(intr_out_empty, 0444, channel_intr_out_empty_show, NULL);
 
-static ssize_t channel_out_full_first_show(struct vmbus_channel *channel,
+static ssize_t channel_out_full_first_show(const struct vmbus_channel *channel,
 					   char *buf)
 {
 	return sprintf(buf, "%llu\n",
@@ -1827,7 +1803,7 @@ static ssize_t channel_out_full_first_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(out_full_first, 0444, channel_out_full_first_show, NULL);
 
-static ssize_t channel_out_full_total_show(struct vmbus_channel *channel,
+static ssize_t channel_out_full_total_show(const struct vmbus_channel *channel,
 					   char *buf)
 {
 	return sprintf(buf, "%llu\n",
@@ -1835,14 +1811,14 @@ static ssize_t channel_out_full_total_show(struct vmbus_channel *channel,
 }
 static VMBUS_CHAN_ATTR(out_full_total, 0444, channel_out_full_total_show, NULL);
 
-static ssize_t subchannel_monitor_id_show(struct vmbus_channel *channel,
+static ssize_t subchannel_monitor_id_show(const struct vmbus_channel *channel,
 					  char *buf)
 {
 	return sprintf(buf, "%u\n", channel->offermsg.monitorid);
 }
 static VMBUS_CHAN_ATTR(monitor_id, S_IRUGO, subchannel_monitor_id_show, NULL);
 
-static ssize_t subchannel_id_show(struct vmbus_channel *channel,
+static ssize_t subchannel_id_show(const struct vmbus_channel *channel,
 				  char *buf)
 {
 	return sprintf(buf, "%u\n",


### PR DESCRIPTION

This reverts commit e792e801d3b72a16bb80b6aef50c333d71c78c52.

Revert because it cause a crash.