### PR TITLE
RH7: scsi: storvsc: Add ability to change scsi queue depth

### DIFF
--- a/hv-rhel7.x/hv/storvsc_drv.c
+++ b/hv-rhel7.x/hv/storvsc_drv.c
@@ -409,6 +409,8 @@ enum storvsc_request_type {
 #define STORVSC_MIN_BUF_NR				64
 static int storvsc_ringbuffer_size = (128 * 1024);
 static u32 max_outstanding_req_per_channel;
+static int storvsc_change_queue_depth(struct scsi_device *sdev, int queue_depth,
+					int reason);
 
 static int storvsc_vcpus_per_sub_channel = 4;
 
@@ -2156,6 +2158,7 @@ static struct scsi_host_template scsi_driver = {
 #ifdef NOTYET
 	.track_queue_depth =	1,
 #endif
+	.change_queue_depth = 	storvsc_change_queue_depth,
 };
 
 enum {
@@ -2365,6 +2368,18 @@ err_out0:
 	scsi_host_put(host);
 	mutex_unlock(&probe_mutex);
 	return ret;
+}
+
+/* Change a scsi target's queue depth */
+static int storvsc_change_queue_depth(struct scsi_device *sdev, int queue_depth,
+					int reason)
+{
+	if (queue_depth > scsi_driver.can_queue)
+		queue_depth = scsi_driver.can_queue;
+
+	scsi_adjust_queue_depth(sdev, scsi_get_tag_type(sdev), queue_depth);
+
+	return sdev->queue_depth;
 }
 
 static int storvsc_remove(struct hv_device *dev)


### PR DESCRIPTION
Backported from upstream:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=adfbd028e155fca3bbe33d458f2f27cb657e5792

This commit is different from original backport because scsi_change_queue_depth
() is not supported in older kernel. We need to use scsi_adjust_queue_depth()
to support queue depth change in older kernel (for RH/CentOS).