### PR TITLE
RH7: netvsc: Modify hv_get_avail_to_write_percent to support older kernel

### DIFF
--- a/hv-rhel7.x/hv/include/linux/hyperv.h
+++ b/hv-rhel7.x/hv/include/linux/hyperv.h
@@ -36,9 +36,7 @@
 #include <linux/device.h>
 #include <linux/mod_devicetable.h>
 #include <linux/interrupt.h>
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 0))
 #include <linux/reciprocal_div.h>
-#endif
 
 #define MAX_PAGE_BUFFER_COUNT				32
 #define MAX_MULTIPAGE_BUFFER_COUNT			32 /* 128K */
@@ -143,6 +141,8 @@ struct hv_ring_buffer_info {
 	u32 ring_size;			/* Include the shared header */
 #if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7,0))
 	struct reciprocal_value ring_size_div10_reciprocal;
+#else
+	u32 ring_size_div10_reciprocal;
 #endif
 	spinlock_t ring_lock;
 
@@ -183,16 +183,13 @@ static inline u32 hv_get_bytes_to_write(const struct hv_ring_buffer_info *rbi)
 	return write;
 }
 
-#if (RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 0))
 static inline u32 hv_get_avail_to_write_percent(const struct hv_ring_buffer_info *rbi)
 {
 	u32 avail_write = hv_get_bytes_to_write(rbi);
 
-	return reciprocal_divide(
-		(avail_write << 3) + (avail_write << 1),
-		rbi->ring_size_div10_reciprocal);
+	return reciprocal_divide((avail_write << 3) + (avail_write << 1),
+					rbi->ring_size_div10_reciprocal);
 }
-#endif
 
 	/*
  * VMBUS version is 32 bit entity broken up into

--- a/hv-rhel7.x/hv/netvsc.c
+++ b/hv-rhel7.x/hv/netvsc.c
@@ -35,12 +35,6 @@
 #include "hyperv_net.h"
 #include "netvsc_trace.h"
 
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7,0))
-#include <linux/reciprocal_div.h>
-#else
-#include <linux/hyperv.h>
-#endif
-
 /*
  * Switch the data path from the synthetic interface to the VF
  * interface.
@@ -676,18 +670,6 @@ void netvsc_device_remove(struct hv_device *device)
 #define RING_AVAIL_PERCENT_HIWATER 20
 #define RING_AVAIL_PERCENT_LOWATER 10
 
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-/*
- * Get the percentage of available bytes to write in the ring.
- * The return value is in range from 0 to 100.
- */
-static u32 hv_ringbuf_avail_percent(const struct hv_ring_buffer_info *ring_info)
-{
-	u32 avail_write = hv_get_bytes_to_write(ring_info);
-	return reciprocal_divide(avail_write * 100, netvsc_ring_reciprocal);
-}
-#endif
-
 static inline void netvsc_free_send_slot(struct netvsc_device *net_device,
 					 u32 index)
 {
@@ -741,16 +723,10 @@ static void netvsc_send_tx_complete(struct net_device *ndev,
 		struct netdev_queue *txq = netdev_get_tx_queue(ndev, q_idx);
 
 		if (netif_tx_queue_stopped(txq) && !net_device->tx_disable &&
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-			 (hv_ringbuf_avail_percent(&channel->outbound) > RING_AVAIL_PERCENT_HIWATER ||
-			 queue_sends < 1))
-		{
-#else
 			(hv_get_avail_to_write_percent(&channel->outbound) >
 			 RING_AVAIL_PERCENT_HIWATER ||
 			 queue_sends < 1))
 		{
-#endif
 			netif_tx_wake_queue(txq);
 			ndev_ctx->eth_stats.wake_queue++;
 		}
@@ -865,11 +841,7 @@ static inline int netvsc_send_pkt(
 	struct netdev_queue *txq = netdev_get_tx_queue(ndev, packet->q_idx);
 	u64 req_id;
 	int ret;
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-	u32 ring_avail = hv_ringbuf_avail_percent(&out_channel->outbound);
-#else
 	u32 ring_avail = hv_get_avail_to_write_percent(&out_channel->outbound);
-#endif
 
 	nvmsg.hdr.msg_type = NVSP_MSG1_TYPE_SEND_RNDIS_PKT;
 	if (skb)

--- a/hv-rhel7.x/hv/netvsc_drv.c
+++ b/hv-rhel7.x/hv/netvsc_drv.c
@@ -47,10 +47,6 @@
 
 #include "hyperv_net.h"
 
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-#include <linux/reciprocal_div.h>
-#endif
-
 #define RING_SIZE_MIN	64
 #define RETRY_US_LO	5000
 #define RETRY_US_HI	10000
@@ -63,10 +59,6 @@ static unsigned int ring_size = 128;
 module_param(ring_size, uint, 0444);
 MODULE_PARM_DESC(ring_size, "Ring buffer size (# of pages)");
 unsigned int netvsc_ring_bytes;
-
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-u32 netvsc_ring_reciprocal;
-#endif
 
 static const u32 default_msg = NETIF_MSG_DRV | NETIF_MSG_PROBE |
 				NETIF_MSG_LINK | NETIF_MSG_IFUP |
@@ -2548,9 +2540,6 @@ static int __init netvsc_drv_init(void)
 			ring_size);
 	}
 	netvsc_ring_bytes = ring_size * PAGE_SIZE;
-#if (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(7, 0))
-	netvsc_ring_reciprocal = reciprocal_value(netvsc_ring_bytes);
-#endif
 
 	ret = vmbus_driver_register(&netvsc_drv);
 	if (ret)

--- a/hv-rhel7.x/hv/ring_buffer.c
+++ b/hv-rhel7.x/hv/ring_buffer.c
@@ -237,6 +237,8 @@ int hv_ringbuffer_init(struct hv_ring_buffer_info *ring_info,
 	ring_info->ring_buffer->feature_bits.value = 1;
 
 	ring_info->ring_size = page_cnt << PAGE_SHIFT;
+	ring_info->ring_size_div10_reciprocal =
+		reciprocal_value(ring_info->ring_size / 10);
 	ring_info->ring_datasize = ring_info->ring_size -
 		sizeof(struct hv_ring_buffer);
 	ring_info->priv_read_index = 0;


### PR DESCRIPTION
Fixes: 553354267fa (RH7: scsi: netvsc: Use the vmbus function to calculate ring buffer percentage (corrected for 7.0|7.x))