### PR TITLE
Install IP injection scripts to /usr/libexec/hypervkvpd

### DIFF
--- a/hv-rhel6.x/hv/rhel6-hv-driver-install
+++ b/hv-rhel6.x/hv/rhel6-hv-driver-install
@@ -27,13 +27,15 @@ cp -f ./hyperv_pvdrivers.conf /etc/modprobe.d/
 
 echo "Copying scripts for IP injection"
 
-\cp -f ./tools/hv_get_dns_info.sh /usr/sbin/hv_get_dns_info
+mkdir -p /usr/libexec/hypervkvpd/
+
+\cp -f ./tools/hv_get_dns_info.sh /usr/libexec/hypervkvpd/hv_get_dns_info
 [ $? -eq 0 ] || exit 1
 
-\cp -f ./tools/hv_get_dhcp_info.sh /usr/sbin/hv_get_dhcp_info
+\cp -f ./tools/hv_get_dhcp_info.sh /usr/libexec/hypervkvpd/hv_get_dhcp_info
 [ $? -eq 0 ] || exit 1
 
-\cp -f ./tools/hv_set_ifconfig.sh /usr/sbin/hv_set_ifconfig
+\cp -f ./tools/hv_set_ifconfig.sh /usr/libexec/hypervkvpd/hv_set_ifconfig
 [ $? -eq 0 ] || exit 1
 
 echo "Copying lsvmbus tool"


### PR DESCRIPTION
Do this because:
hv-rhel6.x/hv/tools/hv_kvp_daemon.c:#define KVP_SCRIPTS_PATH "/usr/libexec/hypervkvpd/"